### PR TITLE
Remove fmt from PR make target

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install make
       run: sudo apt -y install make
     - name: Run verification and tests
-      run: make fmt lint test cov-exclude-generated
+      run: make lint test cov-exclude-generated
     - name: Report coverage
       uses: codecov/codecov-action@v2.1.0
       with:


### PR DESCRIPTION
"make fmt" silently formats the code so you won't get CI errors derived from a wrong text formatting.

Removing this target invocation makes the PR fail if the code is not well formatted (goimports plugin from make lint)