### PR TITLE
Enable remote profiling

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -46,3 +46,5 @@ The following environment variables are available to configure the NetObserv eBF
   means that errors are ignored since the caller will not receive the returned value.
 * `KAFKA_COMPRESSION` (default: `none`). Compression codec to be used to compress messages. Accepted
   values: `none`, `gzip`, `snappy`, `lz4`, `zstd`.
+* `PROFILE_PORT` (default: unset). Sets the listening port for [Go's Pprof tool](https://pkg.go.dev/net/http/pprof).
+  If it is not set, profile is disabled.

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -67,4 +67,6 @@ type Config struct {
 	// KafkaCompression sets the compression codec to be used to compress messages. The accepted
 	// values are: none (default), gzip, snappy, lz4, zstd.
 	KafkaCompression string `env:"KAFKA_COMPRESSION" envDefault:"none"`
+	// ProfilePort sets the listening port for Go's Pprof tool. If it is not set, profile is disabled
+	ProfilePort int `env:"PROFILE_PORT"`
 }


### PR DESCRIPTION
Optionally opens a port for remote profiling using `go pprof` tool: https://go.dev/blog/pprof