### PR TITLE
create systemd unit example

### DIFF
--- a/examples/systemd/netobserv-ebpf-agent
+++ b/examples/systemd/netobserv-ebpf-agent
@@ -1,0 +1,7 @@
+# default settings for netobserv-ebpf-agent
+# used by systemd unit
+# /etc/default/netobserv-ebpf-agent
+
+DIRECTION=both
+FLOWS_TARGET_HOST=127.0.0.1
+FLOWS_TARGET_PORT=9999

--- a/examples/systemd/netobserv-ebpf-agent.service
+++ b/examples/systemd/netobserv-ebpf-agent.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Netobserv eBPF Agent
+After=network.target
+
+[Service]
+EnvironmentFile=-/etc/default/netobserv-ebpf-agent
+ExecStart=/opt/netobserv-ebpf-agent/bin/netobserv-ebpf-agent
+Restart=on-failure
+Type=exec
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I am interested in running this under systemd rather than inside kube. This PR includes an example systemd unit file and environment config file.

```
joe@dev:~$ sudo systemctl status netobserv-ebpf-agent
● netobserv-ebpf-agent.service - Netobserv eBPF Agent
     Loaded: loaded (/lib/systemd/system/netobserv-ebpf-agent.service; disabled; preset: enabled)
     Active: active (running) since Wed 2022-10-05 18:26:05 UTC; 1s ago
   Main PID: 20013 (netobserv-ebpf-)
      Tasks: 8 (limit: 2173)
     Memory: 20.8M
        CPU: 17ms
     CGroup: /system.slice/netobserv-ebpf-agent.service
             └─20013 /opt/netobserv-ebpf-agent/bin/netobserv-ebpf-agent

Oct 05 18:26:05 dev systemd[1]: Started Netobserv eBPF Agent.
Oct 05 18:26:05 dev netobserv-ebpf-agent[20013]: time="2022-10-05T18:26:05Z" level=info msg="starting NetObserv eBPF Agent"
Oct 05 18:26:05 dev netobserv-ebpf-agent[20013]: time="2022-10-05T18:26:05Z" level=info msg="initializing Flows agent" component=agent.Flows
Oct 05 18:26:05 dev netobserv-ebpf-agent[20013]: time="2022-10-05T18:26:05Z" level=info msg="push CTRL+C or send SIGTERM to interrupt execution"
Oct 05 18:26:05 dev netobserv-ebpf-agent[20013]: time="2022-10-05T18:26:05Z" level=info msg="starting Flows agent" component=agent.Flows
Oct 05 18:26:05 dev netobserv-ebpf-agent[20013]: time="2022-10-05T18:26:05Z" level=info msg="Flows agent successfully started" component=agent.Flows
Oct 05 18:26:05 dev netobserv-ebpf-agent[20013]: time="2022-10-05T18:26:05Z" level=info msg="interface detected. Registering flow tracer" component=agent.Flows interface="{enp0s3 2}"
Oct 05 18:26:05 dev netobserv-ebpf-agent[20013]: time="2022-10-05T18:26:05Z" level=warning msg="qdisc clsact already existed. Deleted it" component=ebpf.FlowTracer iface="{enp0s3 2}"
Oct 05 18:26:05 dev netobserv-ebpf-agent[20013]: time="2022-10-05T18:26:05Z" level=info msg="interface detected. Registering flow tracer" component=agent.Flows interface="{docker0 3}"
Oct 05 18:26:05 dev netobserv-ebpf-agent[20013]: time="2022-10-05T18:26:05Z" level=warning msg="qdisc clsact already existed. Deleted it" component=ebpf.FlowTracer iface="{docker0 3}"
```