### PR TITLE
Some code improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cilium/ebpf v0.8.1
 	github.com/gavv/monotime v0.0.0-20190418164738-30dba4353424
 	github.com/mariomac/guara v0.0.0-20220523124851-5fc279816f1f
-	github.com/netobserv/gopipes v0.1.1
+	github.com/netobserv/gopipes v0.2.0
 	github.com/paulbellamy/ratecounter v0.2.0
 	github.com/segmentio/kafka-go v0.4.32
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/netobserv/gopipes v0.1.1 h1:f8zJsvnMgRFRa2B+1siwRtW0Y4dqeBROmkcI/HgT1gE=
-github.com/netobserv/gopipes v0.1.1/go.mod h1:eGoHZW1ON8Dx/zmDXUhsbVNqatPjtpdO0UZBmGZGmVI=
+github.com/netobserv/gopipes v0.2.0 h1:CnJQq32+xNuM85eVYy/HOf+StTJdh2K6RdaEg7NAJDg=
+github.com/netobserv/gopipes v0.2.0/go.mod h1:eGoHZW1ON8Dx/zmDXUhsbVNqatPjtpdO0UZBmGZGmVI=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/pkg/flow/account.go
+++ b/pkg/flow/account.go
@@ -52,6 +52,8 @@ func (c *Accounter) Account(in <-chan *RawRecord, out chan<- []*Record) {
 			}
 			evictingEntries := c.entries
 			c.entries = make(map[RecordKey]*RecordMetrics, c.maxEntries)
+			logrus.WithField("flows", len(evictingEntries)).
+				Debug("evicting flows from userspace accounter on timeout")
 			go c.evict(evictingEntries, out)
 		case record, ok := <-in:
 			if !ok {
@@ -69,12 +71,13 @@ func (c *Accounter) Account(in <-chan *RawRecord, out chan<- []*Record) {
 				if len(c.entries) >= c.maxEntries {
 					evictingEntries := c.entries
 					c.entries = make(map[RecordKey]*RecordMetrics, c.maxEntries)
+					logrus.WithField("flows", len(evictingEntries)).
+						Debug("evicting flows from userspace accounter after reaching cache max length")
 					go c.evict(evictingEntries, out)
 				}
 				c.entries[record.RecordKey] = &record.RecordMetrics
 			}
 		}
-
 	}
 }
 

--- a/vendor/github.com/netobserv/gopipes/pkg/node/options.go
+++ b/vendor/github.com/netobserv/gopipes/pkg/node/options.go
@@ -1,0 +1,22 @@
+package node
+
+type creationOptions struct {
+	// if 0, channel is unbuffered
+	channelBufferLen int
+}
+
+var defaultOptions = creationOptions{
+	channelBufferLen: 0,
+}
+
+// CreationOption allows overriding the default values of node instantiation
+type CreationOption func(options *creationOptions)
+
+// ChannelBufferLen is a node.CreationOption that allows specifying the length of the input
+// channels for a given node. The default value is 0, which means that the channels
+// are unbuffered.
+func ChannelBufferLen(length int) CreationOption {
+	return func(options *creationOptions) {
+		options.channelBufferLen = length
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -106,7 +106,7 @@ github.com/modern-go/reflect2
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 ## explicit
 github.com/munnerz/goautoneg
-# github.com/netobserv/gopipes v0.1.1
+# github.com/netobserv/gopipes v0.2.0
 ## explicit; go 1.17
 github.com/netobserv/gopipes/pkg/internal/connect
 github.com/netobserv/gopipes/pkg/internal/refl


### PR DESCRIPTION
* Removed a pipeline stage that became unneeded after refactoring the tracer to share the channel for all the interfaces.
* Log is not flooded anymore when hundreds of flows were received via ringbuffer
* Updated to go-pipes 0.2.0 and allow setting the buffer length of the pipeline stages
* Minor log messages improvements