### PR TITLE
NETOBSERV-743: update build image & CI tests to Go 1.18 (4.12 backport)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.18']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
     - name: Install make
       run: sudo apt -y install make
     - name: Run verification and tests

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,9 +2,9 @@ name: Pull request checks
 
 on:
   push:
-    branches: [ main ]
+    branches: [ 'main', 'release-*' ]
   pull_request:
-    branches: [ main ]
+    branches: [ 'main', 'release-*' ]
 
 jobs:
   test:

--- a/.github/workflows/pull_request_e2e.yml
+++ b/.github/workflows/pull_request_e2e.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.18']
     steps:
     - name: install make
       run: sudo apt-get install make

--- a/.github/workflows/pull_request_e2e.yml
+++ b/.github/workflows/pull_request_e2e.yml
@@ -3,9 +3,9 @@ name: pull request - e2e tests
 #todo: check caching dependencies: https://github.com/actions/cache
 on:
   push:
-    branches: [ main ]
+    branches: [ 'main', 'release-*' ]
   pull_request:
-    branches: [ main ]
+    branches: [ 'main', 'release-*' ]
 
 jobs:
   e2e-tests:

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.18']
     steps:
       - name: install make
         run: sudo apt-get install make

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.18']
     steps:
       - name: install make
         run: sudo apt-get install make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.18']
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ linters:
     - varcheck
 linters-settings:
   stylecheck:
-    go: "1.17"
+    go: "1.18"
   gocritic:
     enabled-checks:
       - hugeParam

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.17.12 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18.4 as builder
 
 ARG SW_VERSION="unknown"
-ARG GOVERSION="1.17.8"
+ARG GOVERSION="1.18.4"
 
 WORKDIR /opt/app-root
 

--- a/examples/performance/Dockerfile_packet_counter
+++ b/examples/performance/Dockerfile_packet_counter
@@ -1,6 +1,6 @@
 # this file has to be built from the project root directory
 
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 WORKDIR /app
 

--- a/scripts/generators.Dockerfile
+++ b/scripts/generators.Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:35
 
-ARG GOVERSION="1.17.12"
+ARG GOVERSION="1.18.4"
 ARG PROTOCVERSION="3.19.4"
 
 # Installs dependencies that are required to compile eBPF programs


### PR DESCRIPTION
Backport of https://github.com/netobserv/netobserv-ebpf-agent/pull/71