### PR TITLE
NETOBSERV-755: ignore flow direction in deduplication

### DIFF
--- a/pkg/flow/deduper.go
+++ b/pkg/flow/deduper.go
@@ -67,6 +67,7 @@ func (c *deduperCache) isDupe(key *RecordKey) bool {
 	// zeroes fields from key that should be ignored from the flow comparison
 	rk.IFIndex = 0
 	rk.DataLink = DataLink{}
+	rk.Direction = 0
 	// If a flow has been accounted previously, whatever its interface was,
 	// it updates the expiry time for that flow
 	if ele, ok := c.ifaces[rk]; ok {

--- a/pkg/flow/deduper_test.go
+++ b/pkg/flow/deduper_test.go
@@ -21,7 +21,7 @@ var (
 	}, RecordMetrics: RecordMetrics{
 		Packets: 2, Bytes: 456,
 	}}, Interface: "123456789"}
-	// another fow from 2 different interfaces
+	// another fow from 2 different interfaces and directions
 	twoIf1 = &Record{RawRecord: RawRecord{RecordKey: RecordKey{
 		EthProtocol: 1, Direction: 1, Transport: Transport{SrcPort: 333, DstPort: 456},
 		DataLink: DataLink{DstMac: MacAddr{0x1}, SrcMac: MacAddr{0x1}}, IFIndex: 1,
@@ -29,7 +29,7 @@ var (
 		Packets: 2, Bytes: 456,
 	}}, Interface: "eth0"}
 	twoIf2 = &Record{RawRecord: RawRecord{RecordKey: RecordKey{
-		EthProtocol: 1, Direction: 1, Transport: Transport{SrcPort: 333, DstPort: 456},
+		EthProtocol: 1, Direction: 0, Transport: Transport{SrcPort: 333, DstPort: 456},
 		DataLink: DataLink{DstMac: MacAddr{0x2}, SrcMac: MacAddr{0x2}}, IFIndex: 2,
 	}, RecordMetrics: RecordMetrics{
 		Packets: 2, Bytes: 456,


### PR DESCRIPTION
Being also backported to 4.12: https://github.com/netobserv/netobserv-ebpf-agent/pull/75

This is technically a breaking change, as some flows that were marked as "Duplicate: false" will be now marked as "Duplicate: true".

From the Netobserv user experience, this shouldn't have any visible impact as long as they don't set the `agent.debug.env.DEDUPER_JUST_MARK=false` flag.

It should have the positive impact of more accurate metric aggregations.