### PR TITLE
Fix github actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,9 +2,9 @@ name: Pull request checks
 
 on:
   push:
-    branches: [ main ]
+    branches: [ 'main', 'release-*' ]
   pull_request:
-    branches: [ main ]
+    branches: [ 'main', 'release-*' ]
 
 jobs:
   test:

--- a/.github/workflows/pull_request_e2e.yml
+++ b/.github/workflows/pull_request_e2e.yml
@@ -3,9 +3,9 @@ name: pull request - e2e tests
 #todo: check caching dependencies: https://github.com/actions/cache
 on:
   push:
-    branches: [ main ]
+    branches: [ 'main', 'release-*' ]
   pull_request:
-    branches: [ main ]
+    branches: [ 'main', 'release-*' ]
 
 jobs:
   e2e-tests:


### PR DESCRIPTION
PR github actions works well in `release-4.12` branch, but doing a PR againts `main` tries still to get input from GH actions that were removed and don't exist anymore:

<img width="783" alt="image" src="https://user-images.githubusercontent.com/939550/207835152-61515249-d254-48d5-a8b6-3059877fd7da.png">

Comparing `.github` folder between `main` and `release-4.12` this seems to be the unique difference. So I unified both files.