### PR TITLE
ghactions: remove strategy matrix

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,9 +10,6 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: ['1.18']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Go

--- a/.github/workflows/pull_request_e2e.yml
+++ b/.github/workflows/pull_request_e2e.yml
@@ -11,16 +11,13 @@ jobs:
   e2e-tests:
     name: e2e-tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: ['1.18']
     steps:
     - name: install make
       run: sudo apt-get install make
     - name: set up go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ${{ matrix.go }}
+        go-version: 1.18
     - name: checkout
       uses: actions/checkout@v2
     - name: run end-to-end tests


### PR DESCRIPTION
The goal is to allow branch protection rule with these status checks, but we don't want to have to modify every time we update the go version (as they're referred to with their go version included when startegy matrix is used)