### PR TITLE
NETOBSERV-661: fix crash on shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.4 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.18.4 as builder
 
 ARG SW_VERSION="unknown"
 ARG GOVERSION="1.18.4"
@@ -20,7 +20,7 @@ COPY Makefile Makefile
 RUN make compile
 
 # Create final image from minimal + built binary
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.1.0
 WORKDIR /
 COPY --from=builder /opt/app-root/bin/netobserv-ebpf-agent .
 USER 65532:65532

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,6 @@ The following graph provides a birds' eye view on how the different components a
 
 For more info on each component, please check their corresponding Go docs.
 
-
 ```mermaid
 flowchart TD
     E(ebpf.FlowFetcher) --> |"pushes via<br/>RingBuffer"| RB(flow.RingBufTracer)
@@ -14,6 +13,7 @@ flowchart TD
 
     E --> |"polls<br/>PerCPUHashMap"| M(flow.MapTracer)
     RB --> |chan *flow.Record| ACC(flow.Accounter)
+    RB -.-> |flushes| M
     ACC --> |"chan []*flow.Record"| DD(flow.Deduper)
     M --> |"chan []*flow.Record"| DD
 

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -279,8 +279,9 @@ func (m *FlowFetcher) Close() error {
 func doIgnoreNoDev[T any](sysCall func(T) error, dev T, log *logrus.Entry) error {
 	if err := sysCall(dev); err != nil {
 		if errors.Is(err, unix.ENODEV) {
-			log.WithError(err).Debug("can't delete. Probably the " +
-				"associated container or interface has been deleted immediatelly before this task")
+			log.WithError(err).Error("can't delete. Ignore this error if other pods or interfaces " +
+				" are also being deleted at this moment. For example, if you are undeploying " +
+				" a FlowCollector or Deployment where this agent is part of")
 		} else {
 			return err
 		}

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -278,7 +278,7 @@ func (m *FlowFetcher) Close() error {
 // types.
 func doIgnoreNoDev[T any](sysCall func(T) error, dev T, log *logrus.Entry) error {
 	if err := sysCall(dev); err != nil {
-		if err == unix.ENODEV {
+		if errors.Is(err, unix.ENODEV) {
 			log.WithError(err).Debug("can't delete. Probably the " +
 				"associated container or interface has been deleted immediatelly before this task")
 		} else {


### PR DESCRIPTION
The flush operation was done asynchronously in another goroutine so it was frequent that, when the agent is shutdown, the destination channel was closed in the main goroutine while the flush goroutine was performing the channel submission.

This PR verifies, before channel send, that the context of the main goroutine is not closed.

This PR also removes some warnings on shutdown due to the agent trying to close unexisting resources of FLP and the Console Plugin, when they are removed just before the agent shutdown.