### PR TITLE
NETOBSERV-889: fix too many colons in address error

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -192,8 +192,7 @@ func buildFlowExporter(cfg *Config) (node.TerminalFunc[[]*flow.Record], error) {
 			return nil, fmt.Errorf("missing target host or port: %s:%d",
 				cfg.TargetHost, cfg.TargetPort)
 		}
-		target := fmt.Sprintf("%s:%d", cfg.TargetHost, cfg.TargetPort)
-		grpcExporter, err := exporter.StartGRPCProto(target, cfg.GRPCMessageMaxFlows)
+		grpcExporter, err := exporter.StartGRPCProto(cfg.TargetHost, cfg.TargetPort, cfg.GRPCMessageMaxFlows)
 		if err != nil {
 			return nil, err
 		}
@@ -243,9 +242,7 @@ func buildFlowExporter(cfg *Config) (node.TerminalFunc[[]*flow.Record], error) {
 			return nil, fmt.Errorf("missing target host or port: %s:%d",
 				cfg.TargetHost, cfg.TargetPort)
 		}
-		target := fmt.Sprintf("%s:%d", cfg.TargetHost, cfg.TargetPort)
-
-		ipfix, err := exporter.StartIPFIXExporter(target, "udp")
+		ipfix, err := exporter.StartIPFIXExporter(cfg.TargetHost, cfg.TargetPort, "udp")
 		if err != nil {
 			return nil, err
 		}
@@ -255,9 +252,7 @@ func buildFlowExporter(cfg *Config) (node.TerminalFunc[[]*flow.Record], error) {
 			return nil, fmt.Errorf("missing target host or port: %s:%d",
 				cfg.TargetHost, cfg.TargetPort)
 		}
-		target := fmt.Sprintf("%s:%d", cfg.TargetHost, cfg.TargetPort)
-
-		ipfix, err := exporter.StartIPFIXExporter(target, "tcp")
+		ipfix, err := exporter.StartIPFIXExporter(cfg.TargetHost, cfg.TargetPort, "tcp")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/agent/ip.go
+++ b/pkg/agent/ip.go
@@ -83,7 +83,9 @@ func fromExternal(ipType string) (net.IP, error) {
 	// This will just establish an external dialer where we can pickup the external
 	// host address
 	addrStr := "8.8.8.8:80"
-	if ipType == IPTypeIPV6 {
+	// When IPType is "any" and we have interface with IPv6 address only then use ipv6 dns address
+	ip, _ := fromLocal(IPTypeIPV4)
+	if ipType == IPTypeIPV6 || (ipType == IPTypeAny && ip == nil) {
 		addrStr = "[2001:4860:4860::8888]:80"
 	}
 	conn, err := dial("udp", addrStr)

--- a/pkg/grpc/client.go
+++ b/pkg/grpc/client.go
@@ -3,6 +3,7 @@ package grpc
 
 import (
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/pbflow"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/utils"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -13,9 +14,10 @@ type ClientConnection struct {
 	conn   *grpc.ClientConn
 }
 
-func ConnectClient(address string) (*ClientConnection, error) {
+func ConnectClient(hostIP string, hostPort int) (*ClientConnection, error) {
 	// TODO: allow configuring some options (keepalive, backoff...)
-	conn, err := grpc.Dial(address,
+	socket := utils.GetSocket(hostIP, hostPort)
+	conn, err := grpc.Dial(socket,
 		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+)
+
+// GetSocket returns socket string in the correct format based on address family
+func GetSocket(hostIP string, hostPort int) string {
+	socket := fmt.Sprintf("%s:%d", hostIP, hostPort)
+	ipAddr := net.ParseIP(hostIP)
+	if ipAddr != nil && ipAddr.To4() == nil {
+		socket = fmt.Sprintf("[%s]:%d", hostIP, hostPort)
+	}
+	return socket
+}


### PR DESCRIPTION
This PR fixed two issues

1- when hostIP is IPv6 address we endup with following error when gRPC try to connect
```bash
collector="2604:1380:4642:7e00::5b:2055" component=exporter/GRPCProto error="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp: address 2604:1380:4642:7e00::5b:2055: too many colons in address\""
```

for IPv6 we need to use `[2604:1380:4642:7e00::5b]:2055` format.

2- on single stack ipv6 cluster with IPType=="any" , ipv4 DNS address was incorrectly used which prevented ebpf agent to come up and the pod stay in crashloop with this error:-
```bash
time="2023-02-16T21:06:17Z" level=fatal msg="can't instantiate NetObserv eBPF Agent" error="acquiring Agent IP: can't establish an external connection dial udp 8.8.8.8:80: connect: network is unreachable"
```
Signed-off-by: msherif1234 <mmahmoud@redhat.com>