### PR TITLE
NETOBSERV-977: some interfaces on single stack cluster can have both ipv4 and ipv6 linklocal

### DIFF
--- a/pkg/agent/ip.go
+++ b/pkg/agent/ip.go
@@ -113,7 +113,7 @@ func findAddress(addrs []net.Addr, ipType string) (net.IP, bool) {
 }
 
 func getIP(pip net.IP, ipType string) (net.IP, bool) {
-	if pip == nil || pip.IsLoopback() {
+	if pip == nil || pip.IsLoopback() || pip.IsLinkLocalUnicast() {
 		return nil, false
 	}
 	switch ipType {


### PR DESCRIPTION
We need to filter out interfaces with linklocal ips when we decide which socket type to use to connect to google dns server here is an example 
```shell
2: enp0s20f0u5u2c2: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN group default qlen 1000
    link/ether fa:14:54:36:5a:55 brd ff:ff:ff:ff:ff:ff
    inet 169.254.3.1/24 brd 169.254.3.255 scope link dynamic noprefixroute enp0s20f0u5u2c2
       valid_lft 855315sec preferred_lft 855315sec
    inet6 fe80::2021:58f:8cf9:eca6/64 scope link noprefixroute 
       valid_lft forever preferred_lft forever
```