### PR TITLE
NETOBSERV-977: some interfaces could have both ipv4 and ipv6 linklocal [backport]

### DIFF
--- a/pkg/agent/ip.go
+++ b/pkg/agent/ip.go
@@ -113,7 +113,7 @@ func findAddress(addrs []net.Addr, ipType string) (net.IP, bool) {
 }
 
 func getIP(pip net.IP, ipType string) (net.IP, bool) {
-	if pip == nil || pip.IsLoopback() {
+	if pip == nil || pip.IsLoopback() || pip.IsLinkLocalUnicast() {
 		return nil, false
 	}
 	switch ipType {


### PR DESCRIPTION
We need to filter out those interfaces when we decide which socket type to use to connect to google dns server

Signed-off-by: msherif1234 <mmahmoud@redhat.com>
(cherry picked from commit 9a3f45e9bf299914462aacb49abc88682f168030)