### PR TITLE
Filter interfaces by their associated IPs

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,10 @@ The following environment variables are available to configure the NetObserv eBF
   excluded from flow tracing. It takes priority over `INTERFACES` values.
   If an entry is enclosed by slashes (e.g. `/br-/`), it will match as regular expression,
   otherwise it will be matched as a case-sensitive string.
+* `INTERFACE_IPS` (optional) Comma-separated list of IPs in CIDR notation (i.e. 192.0.2.0/24) whose
+  interfaces should be listened on. This is an alternative to specifying `INTERFACES`, useful when
+  you know ahead of time what IPs an interface will have but not the OS-assigned interface name itself.
+  Exclusive with INTERFACES/EXCLUDE_INTERFACES.
 * `SAMPLING` (default: disabled). Rate at which packets should be sampled and sent to the target
   collector. E.g. if set to 10, one out of 10 packets, on average, will be sent to the target
   collector.

--- a/docs/config.md
+++ b/docs/config.md
@@ -24,10 +24,10 @@ The following environment variables are available to configure the NetObserv eBF
   excluded from flow tracing. It takes priority over `INTERFACES` values.
   If an entry is enclosed by slashes (e.g. `/br-/`), it will match as regular expression,
   otherwise it will be matched as a case-sensitive string.
-* `INTERFACE_IPS` (optional) Comma-separated list of IPs in CIDR notation (i.e. 192.0.2.0/24) whose
-  interfaces should be listened on. This is an alternative to specifying `INTERFACES`, useful when
-  you know ahead of time what IPs an interface will have but not the OS-assigned interface name itself.
-  Exclusive with INTERFACES/EXCLUDE_INTERFACES.
+* `INTERFACE_IPS` (optional) Comma-separated list of IPs/Subnets in CIDR notation (i.e. 192.0.2.0/24).
+  Any interface with an associated IP address within the given ranges will be listened on. This is an
+  alternative to specifying `INTERFACES`, useful when you know ahead of time what IP or IP range an
+  interface will have but not the OS-assigned interface name itself. Exclusive with INTERFACES/EXCLUDE_INTERFACES.
 * `SAMPLING` (default: disabled). Rate at which packets should be sampled and sent to the target
   collector. E.g. if set to 10, one out of 10 packets, on average, will be sent to the target
   collector.

--- a/go.mod
+++ b/go.mod
@@ -69,16 +69,16 @@ require (
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
-	github.com/xdg-go/scram v1.1.2 // indirect
-	github.com/xdg-go/stringprep v1.0.4 // indirect
-	golang.org/x/crypto v0.11.0 // indirect
-	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 // indirect
-	golang.org/x/net v0.13.0 // indirect
-	golang.org/x/oauth2 v0.10.0 // indirect
-	golang.org/x/term v0.10.0 // indirect
-	golang.org/x/text v0.11.0 // indirect
-	golang.org/x/time v0.3.0 // indirect
+	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df // indirect
+	github.com/xdg/scram v1.0.5 // indirect
+	github.com/xdg/stringprep v1.0.3 // indirect
+	golang.org/x/crypto v0.5.0 // indirect
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
+	golang.org/x/net v0.7.0 // indirect
+	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
+	golang.org/x/term v0.5.0 // indirect
+	golang.org/x/text v0.7.0 // indirect
+	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -69,16 +69,16 @@ require (
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df // indirect
-	github.com/xdg/scram v1.0.5 // indirect
-	github.com/xdg/stringprep v1.0.3 // indirect
-	golang.org/x/crypto v0.5.0 // indirect
-	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
-	golang.org/x/net v0.7.0 // indirect
-	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
-	golang.org/x/term v0.5.0 // indirect
-	golang.org/x/text v0.7.0 // indirect
-	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.2 // indirect
+	github.com/xdg-go/stringprep v1.0.4 // indirect
+	golang.org/x/crypto v0.11.0 // indirect
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
+	golang.org/x/net v0.13.0 // indirect
+	golang.org/x/oauth2 v0.10.0 // indirect
+	golang.org/x/term v0.10.0 // indirect
+	golang.org/x/text v0.11.0 // indirect
+	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -345,8 +345,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
-golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/netip"
 	"time"
 
 	"github.com/cilium/ebpf/ringbuf"
@@ -185,27 +184,7 @@ func flowsAgent(cfg *Config,
 
 	case len(cfg.InterfaceIPs) > 0:
 		// configure ip interface filter
-		f, err := initIPInterfaceFilter(cfg.InterfaceIPs, func(ifaceName string) ([]netip.Addr, error) {
-			iface, err := net.InterfaceByName(ifaceName)
-			if err != nil {
-				return []netip.Addr{}, fmt.Errorf("error retrieving interface by name: %w", err)
-			}
-			addrs, err := iface.Addrs()
-			if err != nil {
-				return []netip.Addr{}, fmt.Errorf("error retrieving addresses from interface: %w", err)
-			}
-
-			interfaceAddrs := []netip.Addr{}
-			for _, addr := range addrs {
-				prefix, err := netip.ParsePrefix(addr.String())
-				if err != nil {
-					return []netip.Addr{}, fmt.Errorf("parsing given ip to netip.Addr: %w", err)
-				}
-				interfaceAddrs = append(interfaceAddrs, prefix.Addr())
-			}
-			return interfaceAddrs, nil
-
-		})
+		f, err := initIPInterfaceFilter(cfg.InterfaceIPs, IPsFromInterface)
 		if err != nil {
 			return nil, fmt.Errorf("configuring interface ip filter: %w", err)
 		}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -451,6 +451,7 @@ func (f *Flows) onInterfaceAdded(iface ifaces.Interface) {
 	allowed, err := f.filter.Allowed(iface.Name)
 	if err != nil {
 		alog.WithField("interface", iface).Errorf("encountered error determining if interface is allowed: %v", err)
+		return
 	}
 	if !allowed {
 		alog.WithField("interface", iface).

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -179,7 +179,11 @@ func flowsAgent(cfg *Config,
 ) (*Flows, error) {
 	var filter InterfaceFilter
 
-	if len(cfg.InterfaceIPs) > 0 {
+	switch {
+	case len(cfg.InterfaceIPs) > 0 && (len(cfg.Interfaces) > 0 || len(cfg.ExcludeInterfaces) > 0):
+		return nil, fmt.Errorf("INTERFACES/EXCLUDE_INTERFACES and INTERFACE_IPS are mutually exclusive")
+
+	case len(cfg.InterfaceIPs) > 0:
 		// configure ip interface filter
 		f, err := initIPInterfaceFilter(cfg.InterfaceIPs, func(ifaceName string) ([]netip.Addr, error) {
 			iface, err := net.InterfaceByName(ifaceName)
@@ -206,7 +210,8 @@ func flowsAgent(cfg *Config,
 			return nil, fmt.Errorf("configuring interface ip filter: %w", err)
 		}
 		filter = &f
-	} else {
+
+	default:
 		// configure allow/deny regexp interfaces filter
 		f, err := initRegexpInterfaceFilter(cfg.Interfaces, cfg.ExcludeInterfaces)
 		if err != nil {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -181,25 +181,25 @@ func flowsAgent(cfg *Config,
 
 	if len(cfg.InterfaceIPs) > 0 {
 		// configure ip interface filter
-		f, err := initIPInterfaceFilter(cfg.InterfaceIPs, func(ifaceName string) ([]netip.Prefix, error) {
+		f, err := initIPInterfaceFilter(cfg.InterfaceIPs, func(ifaceName string) ([]netip.Addr, error) {
 			iface, err := net.InterfaceByName(ifaceName)
 			if err != nil {
-				return []netip.Prefix{}, fmt.Errorf("error retrieving interface by name: %w", err)
+				return []netip.Addr{}, fmt.Errorf("error retrieving interface by name: %w", err)
 			}
 			addrs, err := iface.Addrs()
 			if err != nil {
-				return []netip.Prefix{}, fmt.Errorf("error retrieving addresses from interface: %w", err)
+				return []netip.Addr{}, fmt.Errorf("error retrieving addresses from interface: %w", err)
 			}
 
-			prefixes := []netip.Prefix{}
+			interfaceAddrs := []netip.Addr{}
 			for _, addr := range addrs {
 				prefix, err := netip.ParsePrefix(addr.String())
 				if err != nil {
-					return []netip.Prefix{}, fmt.Errorf("parsing given ip to netip.Prefix: %w", err)
+					return []netip.Addr{}, fmt.Errorf("parsing given ip to netip.Addr: %w", err)
 				}
-				prefixes = append(prefixes, prefix)
+				interfaceAddrs = append(interfaceAddrs, prefix.Addr())
 			}
-			return prefixes, nil
+			return interfaceAddrs, nil
 
 		})
 		if err != nil {

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -58,6 +58,9 @@ type Config struct {
 	// BuffersLength establishes the length of communication channels between the different processing
 	// stages
 	BuffersLength int `env:"BUFFERS_LENGTH" envDefault:"50"`
+	// InterfaceIPs is a list of IPs whose interfaces should be listened on. This allows users to specify
+	// interfaces without knowing the OS-assigned interface names. Exclusive with Interfaces/ExcludeInterfaces.
+	InterfaceIPs []string `env:"INTERFACE_IPS" envSeparator:","`
 	// ExporterBufferLength establishes the length of the buffer of flow batches (not individual flows)
 	// that can be accumulated before the Kafka or GRPC exporter. When this buffer is full (e.g.
 	// because the Kafka or GRPC endpoint is slow), incoming flow batches will be dropped. If unset,

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -58,8 +58,9 @@ type Config struct {
 	// BuffersLength establishes the length of communication channels between the different processing
 	// stages
 	BuffersLength int `env:"BUFFERS_LENGTH" envDefault:"50"`
-	// InterfaceIPs is a list of IPs whose interfaces should be listened on. This allows users to specify
-	// interfaces without knowing the OS-assigned interface names. Exclusive with Interfaces/ExcludeInterfaces.
+	// InterfaceIPs is a list of CIDR-notation IPs/Subnets where any interface containing an IP in the given ranges
+	// should be listened on. This allows users to specify interfaces without knowing the OS-assigned interface names.
+	// Exclusive with Interfaces/ExcludeInterfaces.
 	InterfaceIPs []string `env:"INTERFACE_IPS" envSeparator:","`
 	// ExporterBufferLength establishes the length of the buffer of flow batches (not individual flows)
 	// that can be accumulated before the Kafka or GRPC exporter. When this buffer is full (e.g.

--- a/pkg/agent/filter.go
+++ b/pkg/agent/filter.go
@@ -21,6 +21,9 @@ type ipInterfaceFilter struct {
 	ipsFromIface func(ifaceName string) ([]netip.Prefix, error)
 }
 
+// initIPInterfaceFilter allows filtering network interfaces that are accepted/exlucded by the user,
+// according to the provided INTERFACE_IPS from the configuration. It allows interfaces where at least
+// one of the provided CIDRs are associated with it.
 func initIPInterfaceFilter(ips []string, ipsFromIface func(ifaceName string) ([]netip.Prefix, error)) (ipInterfaceFilter, error) {
 	ipIfaceFilter := ipInterfaceFilter{}
 	ipIfaceFilter.ipsFromIface = ipsFromIface
@@ -57,7 +60,7 @@ type regexpInterfaceFilter struct {
 	excludedMatches  []string
 }
 
-// initInterfaceFilter allows filtering network interfaces that are accepted/excluded by the user,
+// initRegexpInterfaceFilter allows filtering network interfaces that are accepted/excluded by the user,
 // according to the provided allowed and excluded interfaces from the configuration. It allows
 // matching by exact string or by regular expression
 func initRegexpInterfaceFilter(allowed, excluded []string) (regexpInterfaceFilter, error) {

--- a/pkg/agent/filter.go
+++ b/pkg/agent/filter.go
@@ -2,11 +2,55 @@ package agent
 
 import (
 	"fmt"
+	"net/netip"
 	"regexp"
 	"strings"
+
+	"golang.org/x/exp/slices"
 )
 
-type interfaceFilter struct {
+type InterfaceFilter interface {
+	Allowed(iface string) (bool, error)
+}
+
+type ipInterfaceFilter struct {
+	allowedIPs []netip.Prefix
+	// Almost always going to be a wrapper around getting
+	// the interface from net.InterfaceByName and then calling
+	// .Addrs() on the interface
+	ipsFromIface func(ifaceName string) ([]netip.Prefix, error)
+}
+
+func initIPInterfaceFilter(ips []string, ipsFromIface func(ifaceName string) ([]netip.Prefix, error)) (ipInterfaceFilter, error) {
+	ipIfaceFilter := ipInterfaceFilter{}
+	ipIfaceFilter.ipsFromIface = ipsFromIface
+
+	for _, ip := range ips {
+		prefix, err := netip.ParsePrefix(ip)
+		if err != nil {
+			return ipInterfaceFilter{}, fmt.Errorf("error parsing given ip: %s: %w", ip, err)
+		}
+		ipIfaceFilter.allowedIPs = append(ipIfaceFilter.allowedIPs, prefix)
+	}
+
+	return ipIfaceFilter, nil
+}
+
+func (f *ipInterfaceFilter) Allowed(iface string) (bool, error) {
+	prefixes, err := f.ipsFromIface(iface)
+	if err != nil {
+		return false, fmt.Errorf("error calling ipsFromIface(): %w", err)
+	}
+
+	for _, prefix := range prefixes {
+		if slices.Contains(f.allowedIPs, prefix) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+type regexpInterfaceFilter struct {
 	allowedRegexpes  []*regexp.Regexp
 	allowedMatches   []string
 	excludedRegexpes []*regexp.Regexp
@@ -16,10 +60,10 @@ type interfaceFilter struct {
 // initInterfaceFilter allows filtering network interfaces that are accepted/excluded by the user,
 // according to the provided allowed and excluded interfaces from the configuration. It allows
 // matching by exact string or by regular expression
-func initInterfaceFilter(allowed, excluded []string) (interfaceFilter, error) {
+func initRegexpInterfaceFilter(allowed, excluded []string) (regexpInterfaceFilter, error) {
 	var isRegexp = regexp.MustCompile("^/(.*)/$")
 
-	itf := interfaceFilter{}
+	itf := regexpInterfaceFilter{}
 	for _, definition := range allowed {
 		definition = strings.Trim(definition, " ")
 		// the user defined a /regexp/ between slashes: compile and store it as regular expression
@@ -53,7 +97,7 @@ func initInterfaceFilter(allowed, excluded []string) (interfaceFilter, error) {
 	return itf, nil
 }
 
-func (itf *interfaceFilter) Allowed(name string) bool {
+func (itf *regexpInterfaceFilter) Allowed(name string) (bool, error) {
 	// if the allowed list is empty, any interface is allowed except if it matches the exclusion list
 	allowed := len(itf.allowedRegexpes)+len(itf.allowedMatches) == 0
 	// otherwise, we check if it appears in the allowed lists (both exact match and regexp)
@@ -64,18 +108,18 @@ func (itf *interfaceFilter) Allowed(name string) bool {
 		allowed = allowed || itf.allowedRegexpes[i].MatchString(string(name))
 	}
 	if !allowed {
-		return false
+		return false, nil
 	}
 	// if the interface matches the allow lists, we still need to check that is not excluded
 	for _, match := range itf.excludedMatches {
 		if name == match {
-			return false
+			return false, nil
 		}
 	}
 	for _, re := range itf.excludedRegexpes {
 		if re.MatchString(string(name)) {
-			return false
+			return false, nil
 		}
 	}
-	return true
+	return true, nil
 }

--- a/pkg/agent/filter_test.go
+++ b/pkg/agent/filter_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,36 +9,92 @@ import (
 )
 
 func TestInterfaces_DefaultConfig(t *testing.T) {
-	ifaces, err := initInterfaceFilter(nil, []string{"lo"})
+	ifaces, err := initRegexpInterfaceFilter(nil, []string{"lo"})
 	require.NoError(t, err)
 
-	assert.True(t, ifaces.Allowed("eth0"))
-	assert.True(t, ifaces.Allowed("br-0"))
-	assert.False(t, ifaces.Allowed("lo"))
+	// Allowed
+	for _, iface := range []string{"eth0", "br-0"} {
+		iface := iface
+		allowed, err := ifaces.Allowed(iface)
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	}
+
+	// Not Allowed
+	allowed, err := ifaces.Allowed("lo")
+	require.NoError(t, err)
+	assert.False(t, allowed)
 }
 
 func TestInterfaceFilter_SelectingInterfaces_DefaultExclusion(t *testing.T) {
-	ifaces, err := initInterfaceFilter([]string{"eth0", "/^br-/"}, []string{"lo"})
+	ifaces, err := initRegexpInterfaceFilter([]string{"eth0", "/^br-/"}, []string{"lo"})
 	require.NoError(t, err)
 
-	assert.True(t, ifaces.Allowed("eth0"))
-	assert.True(t, ifaces.Allowed("br-0"))
-	assert.False(t, ifaces.Allowed("eth01"))
-	assert.False(t, ifaces.Allowed("abr-3"))
-	assert.False(t, ifaces.Allowed("lo"))
+	// Allowed
+	for _, iface := range []string{"eth0", "br-0"} {
+		iface := iface
+		allowed, err := ifaces.Allowed(iface)
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	}
+	// Not Allowed
+	for _, iface := range []string{"eth01", "abr-3", "lo"} {
+		iface := iface
+		allowed, err := ifaces.Allowed(iface)
+		require.NoError(t, err)
+		assert.False(t, allowed)
+	}
 }
 
 func TestInterfaceFilter_ExclusionTakesPriority(t *testing.T) {
-
-	ifaces, err := initInterfaceFilter([]string{"/^eth/", "/^br-/"}, []string{"eth1", "/^br-1/"})
+	ifaces, err := initRegexpInterfaceFilter([]string{"/^eth/", "/^br-/"}, []string{"eth1", "/^br-1/"})
 	require.NoError(t, err)
 
-	assert.True(t, ifaces.Allowed("eth0"))
-	assert.True(t, ifaces.Allowed("eth10"))
-	assert.True(t, ifaces.Allowed("eth11"))
-	assert.True(t, ifaces.Allowed("br-2"))
-	assert.True(t, ifaces.Allowed("br-0"))
-	assert.False(t, ifaces.Allowed("eth1"))
-	assert.False(t, ifaces.Allowed("br-1"))
-	assert.False(t, ifaces.Allowed("br-10"))
+	// Allowed
+	for _, iface := range []string{"eth0", "eth-10", "eth11", "br-2", "br-0"} {
+		iface := iface
+		allowed, err := ifaces.Allowed(iface)
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	}
+	// Not Allowed
+	for _, iface := range []string{"eth1", "br-1", "br-10"} {
+		iface := iface
+		allowed, err := ifaces.Allowed(iface)
+		require.NoError(t, err)
+		assert.False(t, allowed)
+	}
+}
+
+func TestInterfaceFilter_InterfaceIPs(t *testing.T) {
+	mockIPByIface := func(iface string) ([]netip.Prefix, error) {
+		switch iface {
+		case "eth0":
+			return []netip.Prefix{netip.MustParsePrefix("198.51.100.1/24")}, nil
+
+		case "eth1":
+			return []netip.Prefix{netip.MustParsePrefix("198.51.100.2/24")}, nil
+
+		default:
+			panic("unexpected interface name")
+		}
+	}
+
+	ifaces, err := initIPInterfaceFilter([]string{"198.51.100.1/24"}, mockIPByIface)
+	require.NoError(t, err)
+
+	// Allowed
+	for _, iface := range []string{"eth0"} {
+		iface := iface
+		allowed, err := ifaces.Allowed(iface)
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	}
+	// Not Allowed
+	for _, iface := range []string{"eth1"} {
+		iface := iface
+		allowed, err := ifaces.Allowed(iface)
+		require.NoError(t, err)
+		assert.False(t, allowed)
+	}
 }

--- a/pkg/agent/filter_test.go
+++ b/pkg/agent/filter_test.go
@@ -75,23 +75,29 @@ func TestInterfaceFilter_InterfaceIPs(t *testing.T) {
 		case "eth1":
 			return []netip.Prefix{netip.MustParsePrefix("198.51.100.2/24")}, nil
 
+		case "eth2":
+			return []netip.Prefix{netip.MustParsePrefix("2001:db8::1/32"), netip.MustParsePrefix("198.51.100.3/24")}, nil
+
+		case "eth3":
+			return []netip.Prefix{netip.MustParsePrefix("2001:db8::2/32")}, nil
+
 		default:
 			panic("unexpected interface name")
 		}
 	}
 
-	ifaces, err := initIPInterfaceFilter([]string{"198.51.100.1/24"}, mockIPByIface)
+	ifaces, err := initIPInterfaceFilter([]string{"198.51.100.1/24", "2001:db8::1/32"}, mockIPByIface)
 	require.NoError(t, err)
 
 	// Allowed
-	for _, iface := range []string{"eth0"} {
+	for _, iface := range []string{"eth0", "eth2"} {
 		iface := iface
 		allowed, err := ifaces.Allowed(iface)
 		require.NoError(t, err)
 		assert.True(t, allowed)
 	}
 	// Not Allowed
-	for _, iface := range []string{"eth1"} {
+	for _, iface := range []string{"eth1", "eth3"} {
 		iface := iface
 		allowed, err := ifaces.Allowed(iface)
 		require.NoError(t, err)

--- a/pkg/agent/filter_test.go
+++ b/pkg/agent/filter_test.go
@@ -67,30 +67,33 @@ func TestInterfaceFilter_ExclusionTakesPriority(t *testing.T) {
 }
 
 func TestInterfaceFilter_InterfaceIPs(t *testing.T) {
-	mockIPByIface := func(iface string) ([]netip.Prefix, error) {
+	mockIPByIface := func(iface string) ([]netip.Addr, error) {
 		switch iface {
 		case "eth0":
-			return []netip.Prefix{netip.MustParsePrefix("198.51.100.1/24")}, nil
+			return []netip.Addr{netip.MustParsePrefix("198.51.100.1/24").Addr()}, nil
 
 		case "eth1":
-			return []netip.Prefix{netip.MustParsePrefix("198.51.100.2/24")}, nil
+			return []netip.Addr{netip.MustParsePrefix("198.51.100.2/24").Addr()}, nil
 
 		case "eth2":
-			return []netip.Prefix{netip.MustParsePrefix("2001:db8::1/32"), netip.MustParsePrefix("198.51.100.3/24")}, nil
+			return []netip.Addr{netip.MustParsePrefix("2001:db8::1/32").Addr(), netip.MustParsePrefix("198.51.100.3/24").Addr()}, nil
 
 		case "eth3":
-			return []netip.Prefix{netip.MustParsePrefix("2001:db8::2/32")}, nil
+			return []netip.Addr{netip.MustParsePrefix("2001:db8::2/32").Addr()}, nil
+
+		case "eth4":
+			return []netip.Addr{netip.MustParsePrefix("192.0.2.120/24").Addr()}, nil
 
 		default:
 			panic("unexpected interface name")
 		}
 	}
 
-	ifaces, err := initIPInterfaceFilter([]string{"198.51.100.1/24", "2001:db8::1/32"}, mockIPByIface)
+	ifaces, err := initIPInterfaceFilter([]string{"198.51.100.1/32", "2001:db8::1/128", "192.0.2.0/24"}, mockIPByIface)
 	require.NoError(t, err)
 
 	// Allowed
-	for _, iface := range []string{"eth0", "eth2"} {
+	for _, iface := range []string{"eth0", "eth2", "eth4"} {
 		iface := iface
 		allowed, err := ifaces.Allowed(iface)
 		require.NoError(t, err)

--- a/pkg/agent/packets_agent.go
+++ b/pkg/agent/packets_agent.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/netip"
 
 	"github.com/cilium/ebpf/perf"
 	"github.com/netobserv/gopipes/pkg/node"
@@ -88,27 +87,7 @@ func packetsAgent(cfg *Config,
 
 	case len(cfg.InterfaceIPs) > 0:
 		// configure ip interface filter
-		f, err := initIPInterfaceFilter(cfg.InterfaceIPs, func(ifaceName string) ([]netip.Addr, error) {
-			iface, err := net.InterfaceByName(ifaceName)
-			if err != nil {
-				return []netip.Addr{}, fmt.Errorf("error retrieving interface by name: %w", err)
-			}
-			addrs, err := iface.Addrs()
-			if err != nil {
-				return []netip.Addr{}, fmt.Errorf("error retrieving addresses from interface: %w", err)
-			}
-
-			interfaceAddrs := []netip.Addr{}
-			for _, addr := range addrs {
-				prefix, err := netip.ParsePrefix(addr.String())
-				if err != nil {
-					return []netip.Addr{}, fmt.Errorf("parsing given ip to netip.Addr: %w", err)
-				}
-				interfaceAddrs = append(interfaceAddrs, prefix.Addr())
-			}
-			return interfaceAddrs, nil
-
-		})
+		f, err := initIPInterfaceFilter(cfg.InterfaceIPs, IPsFromInterface)
 		if err != nil {
 			return nil, fmt.Errorf("configuring interface ip filter: %w", err)
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -316,7 +316,7 @@ golang.org/x/crypto/cryptobyte
 golang.org/x/crypto/cryptobyte/asn1
 golang.org/x/crypto/curve25519
 golang.org/x/crypto/curve25519/internal/field
-# golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
+# golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 ## explicit; go 1.18
 golang.org/x/exp/constraints
 golang.org/x/exp/maps


### PR DESCRIPTION
We have a use case where it's easy for us to pass the IP(s) of the interfaces we'd like to monitor as an environment variable but quite a bit harder to know the names of those interfaces in advance.

Here's a first pass at adding another filter type that allows/disallows interfaces based on whether it's associated with the passed in IPs. There's still some logic around the poller/watcher for interfaces that'd need some additions to also watch for when IPs are attached/unattached and I'm sure other things that would need updates too.

Is there any interest in adding a feature like this? Happy to change approach from what I have here or otherwise do what still needs done to get it merged if so!