### PR TITLE
NETOBSERV-753: Reset ticker if flows flushed when cacheMaxFlows is reached

### DIFF
--- a/pkg/flow/account.go
+++ b/pkg/flow/account.go
@@ -74,6 +74,9 @@ func (c *Accounter) Account(in <-chan *RawRecord, out chan<- []*Record) {
 					logrus.WithField("flows", len(evictingEntries)).
 						Debug("evicting flows from userspace accounter after reaching cache max length")
 					c.evict(evictingEntries, out)
+					// Since we will evict flows because we reached to cacheMaxFlows then reset
+					// evictTimer to avoid unnecessary another eviction when timer expires.
+					evictTick.Reset(c.evictTimeout)
 				}
 				c.entries[record.Id] = &record.Metrics
 			}


### PR DESCRIPTION
ebpf agent optimization to avoid unnecessary flows eviction when `cacheMaxFlows` is reached followed by evictTick timer expiry