### PR TITLE
Update workflow, setup workflow-test

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -1,14 +1,13 @@
 name: Build and push to quay.io
 on:
   push:
-    branches: [ main ]
+    branches: [ main, workflow-test ]
 
 env:
-  REGISTRY_USER: netobserv+github_ci
-  REGISTRY: quay.io/netobserv
-  IMAGE: netobserv-ebpf-agent
-  ORG: netobserv
-  VERSION: main
+  WF_REGISTRY_USER: netobserv+github_ci
+  WF_ORG: netobserv
+  WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le
+  WF_VERSION: ${{ github.ref_name }}
 
 jobs:
   push-image:
@@ -29,10 +28,12 @@ jobs:
       - name: docker login to quay.io
         uses: docker/login-action@v2
         with:
-          username: ${{ env.REGISTRY_USER }}
+          username: ${{ env.WF_REGISTRY_USER }}
           password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
+      - name: get short sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: build and push manifest with images
-        run: IMAGE_ORG=${{ env.ORG }} VERSION=${{ env.VERSION }} make ci
-      - name: print image url
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        run: |
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.WF_VERSION }} make images
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.short_sha }} OCI_BUILD_OPTS="--label quay.expires-after=2w" make images

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -4,10 +4,10 @@ on:
     types: [labeled]
 
 env:
-  REGISTRY_USER: netobserv+github_ci
-  REGISTRY: quay.io/netobserv
-  IMAGE: netobserv-ebpf-agent
-  ORG: netobserv
+  WF_REGISTRY_USER: netobserv+github_ci
+  WF_REGISTRY: quay.io/netobserv
+  WF_IMAGE: netobserv-ebpf-agent
+  WF_ORG: netobserv
 
 jobs:
   push-pr-image:
@@ -31,15 +31,13 @@ jobs:
       - name: docker login to quay.io
         uses: docker/login-action@v2
         with:
-          username: ${{ env.REGISTRY_USER }}
+          username: ${{ env.WF_REGISTRY_USER }}
           password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
       - name: get short sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-      - name: build and push images
-        run: IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make images
-      - name: build and push manifest
-        run: IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make ci-manifest
+      - name: build and push manifest with images
+        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} make images
       - uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -48,5 +46,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'New image: ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }}. It will expire after two weeks.'
+              body: 'New image: ${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }}. It will expire after two weeks.'
             })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,16 +4,14 @@ on:
     tags: [v*]
 
 env:
-  REGISTRY_USER: netobserv+github_ci
-  REGISTRY_PASSWORD: ${{ secrets.QUAY_SECRET }}
-  REGISTRY: quay.io/netobserv
-  IMAGE: netobserv-ebpf-agent
-  IMAGE_ORG: netobserv
+  WF_REGISTRY_USER: netobserv+github_ci
+  WF_ORG: netobserv
+  WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le
 
 jobs:
   push-image:
     name: push image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         go: ['1.19']
@@ -40,10 +38,8 @@ jobs:
       - name: docker login to quay.io
         uses: docker/login-action@v2
         with:
-          username: ${{ env.REGISTRY_USER }}
-          password: ${{ env.REGISTRY_PASSWORD }}
+          username: ${{ env.WF_REGISTRY_USER }}
+          password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
-      - name: build and push images
-        run: VERSION="${{ env.tag }}" make images
-      - name: print image url
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+      - name: build and push manifest with images
+        run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} make images

--- a/.mk/shortcuts.mk
+++ b/.mk/shortcuts.mk
@@ -17,15 +17,3 @@ push-manifest: manifest-push ## Push MULTIARCH_TARGETS manifest
 
 .PHONY: images
 images: image-build image-push manifest-build manifest-push ## Build and push MULTIARCH_TARGETS images and related manifest
-
-.PHONY: build-ci-manifest
-build-ci-manifest: ci-manifest-build ## Build CI manifest
-
-.PHONY: push-ci-manifest
-push-ci-manifest: ci-manifest-push ## Push CI manifest
-
-.PHONY: ci-manifest
-ci-manifest: ci-manifest-build ci-manifest-push ## Build and push CI manifest
-
-.PHONY: ci
-ci: images ci-manifest ## Build and push CI images and manifest

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 # Go architecture and targets images to build
 GOARCH ?= amd64
-MULTIARCH_TARGETS ?= amd64 arm64 ppc64le
+MULTIARCH_TARGETS ?= amd64
 
 # In CI, to be replaced by `netobserv`
 IMAGE_ORG ?= $(USER)
@@ -28,7 +28,7 @@ IMAGE_TAG_BASE ?= quay.io/$(IMAGE_ORG)/netobserv-ebpf-agent
 
 # Image URL to use all building/pushing image targets
 IMAGE ?= $(IMAGE_TAG_BASE):$(VERSION)
-IMAGE_SHA = $(IMAGE_TAG_BASE):$(BUILD_SHA)
+OCI_BUILD_OPTS ?=
 
 # Image building tool (docker / podman)
 OCI_BIN_PATH := $(shell which podman  || which docker)
@@ -49,7 +49,7 @@ EXCLUDE_COVERAGE_FILES="(/cmd/)|(bpf_bpfe)|(/examples/)|(/pkg/pbflow/)"
 # build a single arch target provided as argument
 define build_target
 	echo 'building image for arch $(1)'; \
-	DOCKER_BUILDKIT=1 $(OCI_BIN) buildx build --load --build-arg TARGETPLATFORM=linux/$(1) --build-arg TARGETARCH=$(1) --build-arg BUILDPLATFORM=linux/amd64 -t ${IMAGE}-$(1) -f Dockerfile .;
+	DOCKER_BUILDKIT=1 $(OCI_BIN) buildx build --load --build-arg TARGETPLATFORM=linux/$(1) --build-arg TARGETARCH=$(1) --build-arg BUILDPLATFORM=linux/amd64 ${OCI_BUILD_OPTS} -t ${IMAGE}-$(1) -f Dockerfile .;
 endef
 
 # push a single arch target image
@@ -59,9 +59,9 @@ define push_target
 endef
 
 # manifest create a single arch target provided as argument
-define manifest_create_target
-	echo 'manifest create for arch $(1)'; \
-	DOCKER_BUILDKIT=1 $(OCI_BIN) manifest add ${IMAGE} ${IMAGE}-$(target);
+define manifest_add_target
+	echo 'manifest add target $(1)'; \
+	DOCKER_BUILDKIT=1 $(OCI_BIN) manifest add ${IMAGE} ${IMAGE}-$(1);
 endef
 
 ##@ General
@@ -181,7 +181,7 @@ ifeq (${OCI_BIN}, docker)
 else
 	trap 'exit' INT; \
 	DOCKER_BUILDKIT=1 $(OCI_BIN) manifest create ${IMAGE} ||:
-	$(foreach target,$(MULTIARCH_TARGETS),$(call manifest_create_target,$(target)))
+	$(foreach target,$(MULTIARCH_TARGETS),$(call manifest_add_target,$(target)))
 endif
 
 .PHONY: manifest-push
@@ -191,23 +191,6 @@ ifeq (${OCI_BIN}, docker)
 	DOCKER_BUILDKIT=1 $(OCI_BIN) manifest push ${IMAGE};
 else
 	DOCKER_BUILDKIT=1 $(OCI_BIN) manifest push ${IMAGE} docker://${IMAGE};
-endif
-
-.PHONY: ci-manifest-build
-ci-manifest-build: manifest-build ## Build CI manifest
-	$(OCI_BIN) build --build-arg BASE_IMAGE=$(IMAGE) -t $(IMAGE_SHA) -f scripts/shortlived.Dockerfile .
-ifeq ($(VERSION), main)
-# Also tag "latest" only for branch "main"
-	$(OCI_BIN) build -t $(IMAGE) -t $(IMAGE_TAG_BASE):latest -f scripts/shortlived.Dockerfile .
-endif
-
-.PHONY: ci-manifest-push
-ci-manifest-push: ## Push CI manifest
-	$(OCI_BIN) push $(IMAGE_SHA)
-ifeq ($(VERSION), main)
-# Also tag "latest" only for branch "main"
-	$(OCI_BIN) push ${IMAGE}
-	$(OCI_BIN) push $(IMAGE_TAG_BASE):latest
 endif
 
 include .mk/shortcuts.mk

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,10 +9,3 @@ to run this script unless you want to e.g. update any of them to a newer version
 
 Dockerfile for the eBPF binaries and Protobuf implementation generator. It is invoked from the root
 `Makefile`, in the `make docker-generate` target.
-
-## `shortlived.Dockerfile`
-
-Dockerfile to generate a short-lived image of the agent that corresponds to the commits in the
-`main` branch of the project Git.
-
-The published images expire after 2 weeks.

--- a/scripts/shortlived.Dockerfile
+++ b/scripts/shortlived.Dockerfile
@@ -1,3 +1,0 @@
-ARG BASE_IMAGE=quay.io/netobserv/netobserv-ebpf-agent:main
-FROM $BASE_IMAGE
-LABEL quay.expires-after=2w


### PR DESCRIPTION
- Can trigger workflow from branch workflow-test
- Make default multi-arch to single amd64
- Remove specific ci targets; make shortlive builds more straightforward
- Disambiguate makefile env vs workflow env
- Remove unused targets
- Remove now unused shortlived dockerfile