### PR TITLE
WIP NETOBSERV-1107  Using batchAPIs to help with CPU and memory resources

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -78,7 +78,7 @@ type ebpfFlowFetcher interface {
 	io.Closer
 	Register(iface ifaces.Interface) error
 
-	LookupAndDeleteMap() map[ebpf.BpfFlowId]*ebpf.BpfFlowMetrics
+	LookupAndDeleteMap(enbaleGC bool) map[ebpf.BpfFlowId]*ebpf.BpfFlowMetrics
 	ReadRingBuf() (ringbuf.Record, error)
 }
 

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"runtime"
 	"strings"
 
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/ifaces"
@@ -410,17 +411,34 @@ func (m *FlowFetcher) ReadRingBuf() (ringbuf.Record, error) {
 // This way we avoid missing packets that could be updated on the
 // ebpf side while we process/aggregate them here
 // Changing this method invocation by BatchLookupAndDelete could improve performance
-// TODO: detect whether BatchLookupAndDelete is supported (Kernel>=5.6) and use it selectively
-// Supported Lookup/Delete operations by kernel: https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md
 // Race conditions here causes that some flows are lost in high-load scenarios
-func (m *FlowFetcher) LookupAndDeleteMap() map[BpfFlowId]*BpfFlowMetrics {
+func (m *FlowFetcher) LookupAndDeleteMap(enableGC bool) map[BpfFlowId]*BpfFlowMetrics {
 	flowMap := m.objects.AggregatedFlows
 
-	iterator := flowMap.Iterate()
 	var flow = make(map[BpfFlowId]*BpfFlowMetrics, m.cacheMaxSize)
 	var id BpfFlowId
 	var metric BpfFlowMetrics
+	var ids = make([]BpfFlowId, m.cacheMaxSize)
+	var metrics = make([]BpfFlowMetrics, m.cacheMaxSize)
 
+	iterator := flowMap.Iterate()
+	if iterator.Next(&id, &metric) {
+		count, err := flowMap.BatchLookupAndDelete(nil, &id, ids, metrics, nil)
+		if (err == nil || errors.Is(err, ebpf.ErrKeyNotExist)) && count > 0 {
+			for i := 0; i < count; i++ {
+				flow[ids[i]] = &metrics[i]
+			}
+			if enableGC {
+				runtime.KeepAlive(flow) // Keeps a reference to flow map so that map isn't collected
+				runtime.GC()
+			}
+			return flow
+		}
+		log.Debugf("failed to use BatchLookupAndDelete api: %v fall back to use iterate and delete api", err)
+	}
+	// fallback to iterate and delete if the BatchLookupAndDelete() not supported,
+	// reinitialize iterator to start from the beginning of the map
+	iterator = flowMap.Iterate()
 	// Changing Iterate+Delete by LookupAndDelete would prevent some possible race conditions
 	// TODO: detect whether LookupAndDelete is supported (Kernel>=4.20) and use it selectively
 	for iterator.Next(&id, &metric) {

--- a/pkg/flow/tracer_map.go
+++ b/pkg/flow/tracer_map.go
@@ -26,7 +26,7 @@ type MapTracer struct {
 }
 
 type mapFetcher interface {
-	LookupAndDeleteMap() map[ebpf.BpfFlowId]*ebpf.BpfFlowMetrics
+	LookupAndDeleteMap(enableGC bool) map[ebpf.BpfFlowId]*ebpf.BpfFlowMetrics
 }
 
 func NewMapTracer(fetcher mapFetcher, evictionTimeout time.Duration) *MapTracer {
@@ -92,7 +92,7 @@ func (m *MapTracer) evictFlows(ctx context.Context, enableGC bool, forwardFlows 
 
 	var forwardingFlows []*Record
 	laterFlowNs := uint64(0)
-	for flowKey, flowMetrics := range m.mapFetcher.LookupAndDeleteMap() {
+	for flowKey, flowMetrics := range m.mapFetcher.LookupAndDeleteMap(enableGC) {
 		aggregatedMetrics := flowMetrics
 		// we ignore metrics that haven't been aggregated (e.g. all the mapped values are ignored)
 		if aggregatedMetrics.EndMonoTimeTs == 0 {

--- a/pkg/test/tracer_fake.go
+++ b/pkg/test/tracer_fake.go
@@ -33,7 +33,7 @@ func (m *TracerFake) Register(iface ifaces.Interface) error {
 	return nil
 }
 
-func (m *TracerFake) LookupAndDeleteMap() map[ebpf.BpfFlowId]*ebpf.BpfFlowMetrics {
+func (m *TracerFake) LookupAndDeleteMap(_ bool) map[ebpf.BpfFlowId]*ebpf.BpfFlowMetrics {
 	select {
 	case r := <-m.mapLookups:
 		return r

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -14,24 +14,21 @@ func TestIskernelOlderthan514(t *testing.T) {
 		{
 			name: "Kernel version < 5.14.0",
 			mockKernelVersion: func() (uint32, error) {
-				ver, _ := kernelVersionFromReleaseString("5.13.0")
-				return ver, nil
+				return kernelVersionFromReleaseString("5.13.0")
 			},
 			want: true,
 		},
 		{
 			name: "Kernel version = 5.14.0",
 			mockKernelVersion: func() (uint32, error) {
-				ver, _ := kernelVersionFromReleaseString("5.14.0")
-				return ver, nil
+				return kernelVersionFromReleaseString("5.14.0")
 			},
 			want: false,
 		},
 		{
 			name: "Kernel version > 5.14.0",
 			mockKernelVersion: func() (uint32, error) {
-				ver, _ := kernelVersionFromReleaseString("5.15.0")
-				return ver, nil
+				return kernelVersionFromReleaseString("5.15.0")
 			},
 			want: false,
 		},


### PR DESCRIPTION
```sh
top5
Showing nodes accounting for 95.46GB, 97.45% of 97.96GB total
Dropped 215 nodes (cum <= 0.49GB)
Showing top 5 nodes out of 17
      flat  flat%   sum%        cum   cum%
   40.85GB 41.70% 41.70%    96.11GB 98.12%  github.com/netobserv/netobserv-ebpf-agent/pkg/ebpf.(*FlowFetcher).LookupAndDeleteMap <<<<<<<<<<<<<<
   16.05GB 16.39% 58.09%    16.05GB 16.39%  reflect.unsafe_NewArray
   12.89GB 13.16% 71.25%    12.89GB 13.16%  encoding/binary.Read
   12.85GB 13.12% 84.36%    41.75GB 42.63%  github.com/cilium/ebpf.unmarshalPerCPUValue
   12.82GB 13.09% 97.45%    12.82GB 13.09%  github.com/cilium/ebpf.makeBuffer (inline)
```