### PR TITLE
fix build for s390x and ppc64le

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -81,7 +81,7 @@ func currentKernelVersion() (uint32, error) {
 	return kernelVersionFromReleaseString(releaseString)
 }
 
-func utsnameStr(in []int8) string {
+func utsnameStr[T int8 | uint8](in []T) string {
 	out := make([]byte, len(in))
 	for i := 0; i < len(in); i++ {
 		if in[i] == 0 {


### PR DESCRIPTION
ppc64le and s390x for some reason they use `uint8` instead of `int8` for this type
https://pkg.go.dev/syscall#Utsname
leading to this build error
```sh
6.662 pkg/utils/utils.go:80:54: cannot use buf.Release[:] (value of type []uint8) as []int8 value in argument to utsnameStr
```

Fix to create two instances of utils package based on arch check

- unit-tests
```sh
 docker images
REPOSITORY                               TAG            IMAGE ID       CREATED          SIZE
quay.io/mmahmoud/netobserv-ebpf-agent    main-s390x     bd818f928693   24 seconds ago   117MB
quay.io/mmahmoud/netobserv-ebpf-agent    main-amd64     1b01b143841e   5 minutes ago    118MB
quay.io/netobserv/netobserv-ebpf-agent   main-amd64     1b01b143841e   5 minutes ago    118MB
quay.io/mmahmoud/netobserv-ebpf-agent    main-ppc64le   b01ba81f8e67   6 minutes ago    141MB
```
