### PR TITLE
NETOBSERV-1223: check Maps to make sure not nil b4 iterating

### DIFF
--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -452,12 +452,14 @@ func (m *FlowFetcher) lookupAndDeleteDNSMap(timeOut time.Duration) {
 	var dnsKey BpfDnsFlowId
 	var dnsVal uint64
 
-	iterator := dnsMap.Iterate()
-	for iterator.Next(&dnsKey, &dnsVal) {
-		if time.Duration(uint64(monotonicTimeNow)-dnsVal) >= timeOut {
-			if err := dnsMap.Delete(dnsKey); err != nil {
-				log.WithError(err).WithField("dnsKey", dnsKey).
-					Warnf("couldn't delete DNS record entry")
+	if dnsMap != nil {
+		iterator := dnsMap.Iterate()
+		for iterator.Next(&dnsKey, &dnsVal) {
+			if time.Duration(uint64(monotonicTimeNow)-dnsVal) >= timeOut {
+				if err := dnsMap.Delete(dnsKey); err != nil {
+					log.WithError(err).WithField("dnsKey", dnsKey).
+						Warnf("couldn't delete DNS record entry")
+				}
 			}
 		}
 	}
@@ -471,12 +473,14 @@ func (m *FlowFetcher) lookupAndDeleteRTTMap(timeOut time.Duration) {
 	var rttKey BpfFlowSeqId
 	var rttVal uint64
 
-	iterator := rttMap.Iterate()
-	for iterator.Next(&rttKey, &rttVal) {
-		if time.Duration(uint64(monotonicTimeNow)-rttVal) >= timeOut {
-			if err := rttMap.Delete(rttKey); err != nil {
-				log.WithError(err).WithField("rttKey", rttKey).
-					Warnf("couldn't delete RTT record entry")
+	if rttMap != nil {
+		iterator := rttMap.Iterate()
+		for iterator.Next(&rttKey, &rttVal) {
+			if time.Duration(uint64(monotonicTimeNow)-rttVal) >= timeOut {
+				if err := rttMap.Delete(rttKey); err != nil {
+					log.WithError(err).WithField("rttKey", rttKey).
+						Warnf("couldn't delete RTT record entry")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
there is some behavior difference with maps between rhel8 and rhel9
on rhel8 it seems maps not even allocated until its populated leading to this issue while in rhel9 that doesn't seem to be the case.

To be on safe side lets make sure maps pointer is != nil before doing invoking `Iterate`