### PR TITLE
NETOBSERV-1240: prefer flows with DNS records when checking for DNS [backport]

### DIFF
--- a/pkg/flow/deduper_test.go
+++ b/pkg/flow/deduper_test.go
@@ -23,7 +23,7 @@ var (
 	}, Metrics: ebpf.BpfFlowMetrics{
 		Packets: 2, Bytes: 456, Flags: 1,
 	}}, Interface: "123456789"}
-	// another fow from 2 different interfaces and directions
+	// another flow from 2 different interfaces and directions
 	twoIf1 = &Record{RawRecord: RawRecord{Id: ebpf.BpfFlowId{
 		EthProtocol: 1, Direction: 1, SrcPort: 333, DstPort: 456,
 		DstMac: MacAddr{0x1}, SrcMac: MacAddr{0x1}, IfIndex: 1,
@@ -36,6 +36,20 @@ var (
 	}, Metrics: ebpf.BpfFlowMetrics{
 		Packets: 2, Bytes: 456, Flags: 1,
 	}}, Interface: "123456789"}
+	// another flow from 2 different interfaces and directions with DNS latency set on the latest
+	threeIf1 = &Record{RawRecord: RawRecord{Id: ebpf.BpfFlowId{
+		EthProtocol: 1, Direction: 1, SrcPort: 433, DstPort: 456,
+		DstMac: MacAddr{0x1}, SrcMac: MacAddr{0x1}, IfIndex: 1,
+	}, Metrics: ebpf.BpfFlowMetrics{
+		Packets: 2, Bytes: 456, Flags: 1,
+	}}, Interface: "eth0"}
+	threeIf2 = &Record{RawRecord: RawRecord{Id: ebpf.BpfFlowId{
+		EthProtocol: 1, Direction: 0, SrcPort: 433, DstPort: 456,
+		DstMac: MacAddr{0x2}, SrcMac: MacAddr{0x2}, IfIndex: 2,
+	}, Metrics: ebpf.BpfFlowMetrics{
+		Packets: 2, Bytes: 456, Flags: 1,
+		DnsRecord: ebpf.BpfDnsRecordT{Id: 1, Flags: 100, Latency: 1000},
+	}}, Interface: "123456789", DNSLatency: time.Millisecond}
 )
 
 func TestDedupe(t *testing.T) {
@@ -45,21 +59,28 @@ func TestDedupe(t *testing.T) {
 	go Dedupe(time.Minute, false)(input, output)
 
 	input <- []*Record{
-		oneIf2, // record 1 at interface 2: should be accepted
-		twoIf1, // record 2 at interface 1: should be accepted
-		oneIf1, // record 1 duplicate at interface 1: should NOT be accepted
-		oneIf1, //                                        (same record key, different interface)
-		twoIf2, // record 2 duplicate at interface 2: should NOT be accepted
-		oneIf2, // record 1 at interface 1: should be accepted (same record key, same interface)
+		oneIf2,   // record 1 at interface 2: should be accepted
+		twoIf1,   // record 2 at interface 1: should be accepted
+		oneIf1,   // record 1 duplicate at interface 1: should NOT be accepted
+		oneIf1,   //                                        (same record key, different interface)
+		twoIf2,   // record 2 duplicate at interface 2: should NOT be accepted
+		oneIf2,   // record 1 at interface 1: should be accepted (same record key, same interface)
+		threeIf1, // record 1 has no DNS so it get enriched with DNS record from the following record
+		threeIf2, // record 2 is duplicate of record1 and have DNS info , should not be accepted
 	}
 	deduped := receiveTimeout(t, output)
-	assert.Equal(t, []*Record{oneIf2, twoIf1, oneIf2}, deduped)
+	assert.Equal(t, []*Record{oneIf2, twoIf1, oneIf2, threeIf1}, deduped)
 
 	// should still accept records with same key, same interface,
 	// and discard these with same key, different interface
 	input <- []*Record{oneIf1, oneIf2}
 	deduped = receiveTimeout(t, output)
 	assert.Equal(t, []*Record{oneIf2}, deduped)
+
+	// make sure flow with no DNS get enriched with the DNS record
+	assert.Equal(t, threeIf1.Metrics.DnsRecord.Id, threeIf2.Metrics.DnsRecord.Id)
+	assert.Equal(t, threeIf1.Metrics.DnsRecord.Flags, threeIf2.Metrics.DnsRecord.Flags)
+	assert.Equal(t, threeIf1.Metrics.DnsRecord.Latency, threeIf2.Metrics.DnsRecord.Latency)
 }
 
 func TestDedupe_EvictFlows(t *testing.T) {


### PR DESCRIPTION
backport fix for #174

Signed-off-by: msherif1234 <mmahmoud@redhat.com>
(cherry picked from commit cca4aa32f9c3b40d00a1c1225f25ed1ffeea628c)