### PR TITLE
NETOBSERV-1312: remove GC from ring buff mapper not needed

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -363,8 +363,8 @@ func (f *Flows) buildAndStartPipeline(ctx context.Context) (*node.Terminal[[]*fl
 	}
 
 	alog.Debug("connecting flows' processing graph")
-	mapTracer := node.AsStart(f.mapTracer.TraceLoop(ctx, f.cfg.EnableGC))
-	rbTracer := node.AsStart(f.rbTracer.TraceLoop(ctx, f.cfg.EnableGC))
+	mapTracer := node.AsStart(f.mapTracer.TraceLoop(ctx, f.cfg.ForceGC))
+	rbTracer := node.AsStart(f.rbTracer.TraceLoop(ctx))
 
 	accounter := node.AsMiddle(f.accounter.Account,
 		node.ChannelBufferLen(f.cfg.BuffersLength))

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -140,8 +140,8 @@ type Config struct {
 	// This feature requires the flows agent to attach at both Ingress and Egress hookpoints.
 	// If both Ingress and Egress are not enabled then this feature will not be enabled even if set to true via env.
 	EnableRTT bool `env:"ENABLE_RTT" envDefault:"false"`
-	// EnableGC enables golang garbage collection run at the end of every map eviction, default is true
-	EnableGC bool `env:"ENABLE_GARBAGE_COLLECTION" envDefault:"true"`
+	// ForceGC enables forcing golang garbage collection run at the end of every map eviction, default is true
+	ForceGC bool `env:"FORCE_GARBAGE_COLLECTION" envDefault:"true"`
 	// EnablePktDrops enable Packet drops eBPF hook to account for dropped flows
 	EnablePktDrops bool `env:"ENABLE_PKT_DROPS" envDefault:"false"`
 	// EnableDNSTracking enable DNS tracking eBPF hook to track dns query/response flows


### PR DESCRIPTION
## Description

doing GC for ring buff was adding GC cpu overhead while its not really needed, this was very obvious when use `sampling: 1` and run with load `./hey-ho.sh -r 5 -z 10m -p -n 3 -q 800 -d 10`
## Dependencies


n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
