### PR TITLE
NETOBSERV-1317: change netns errors to warnings to avoid confustion

### DIFF
--- a/pkg/ifaces/watcher.go
+++ b/pkg/ifaces/watcher.go
@@ -123,7 +123,7 @@ func getNetNSHandles() ([]netns.NsHandle, error) {
 	log := logrus.WithField("component", "ifaces.Watcher")
 	files, err := os.ReadDir(netnsVolume)
 	if err != nil {
-		log.WithError(err).Error("can't detect any network-namespaces")
+		log.Warningf("can't detect any network-namespaces err: %v [Ignore if the agent privileged flag is not set]", err)
 		return nil, fmt.Errorf("failed to list network-namespaces: %w", err)
 	}
 
@@ -188,6 +188,6 @@ func (w *Watcher) netnsNotify(ctx context.Context, out chan Event) {
 
 	err = w.netnsWatcher.Add(netnsVolume)
 	if err != nil {
-		log.WithError(err).Error("failed to add watcher to netns directory")
+		log.Warningf("failed to add watcher to netns directory err: %v [Ignore if the agent privileged flag is not set]", err)
 	}
 }


### PR DESCRIPTION
## Description

replace netns errors with warning since the default case is running 
with `privileged: false` 
## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [X] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
