### PR TITLE
NETOBSERV-926: Fix kafka and connection tracking

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -267,7 +267,7 @@ func buildKafkaExporter(cfg *Config) (node.TerminalFunc[[]*flow.Record], error) 
 			Async:        cfg.KafkaAsync,
 			Compression:  compression,
 			Transport:    &transport,
-			Balancer:     &kafkago.RoundRobin{},
+			Balancer:     &kafkago.Hash{},
 		},
 	}).ExportFlows, nil
 }


### PR DESCRIPTION
## Description

Fix kafka writer configuration causing kafka to ignore key for partition distribution

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [x] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
