### PR TITLE
NETOBSERV-59 Add tcp flow stream exporter

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	// If the AgentIP configuration property is set, this property has no effect.
 	AgentIPType string `env:"AGENT_IP_TYPE" envDefault:"any"`
 	// Export selects the flows' exporter protocol. Accepted values are: grpc (default), kafka,
-	// ipfix+udp, ipfix+tcp or direct-flp.
+	// ipfix+udp, ipfix+tcp, tcp or direct-flp.
 	Export string `env:"EXPORT" envDefault:"grpc"`
 	// TargetHost is the host name or IP of the target Flow collector, when the EXPORT variable is
 	// set to "grpc"

--- a/pkg/exporter/flows.go
+++ b/pkg/exporter/flows.go
@@ -1,0 +1,66 @@
+package exporter
+
+import (
+	"encoding/json"
+	"net"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/decode"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/flow"
+)
+
+type FlowStream struct {
+	hostPort   string
+	clientConn net.Conn
+}
+
+// WriteFlow writes the given flow data out to the file.
+func writeFlow(record *config.GenericMap, conn net.Conn) error {
+	b, err := json.Marshal(record)
+	if err != nil {
+		plog.Fatal(err)
+	}
+	// append new line between each record to split on client side
+	b = append(b, []byte("\n")...)
+	_, err = conn.Write(b)
+	if err != nil {
+		plog.Fatal(err)
+	}
+	return err
+}
+
+// FIXME: Only after client connects to it, the agent starts collecting and sending flows.
+// This behavior needs to be fixed.
+func StartFlowSend(hostPort string) (*FlowStream, error) {
+	PORT := ":" + hostPort
+	l, err := net.Listen("tcp", PORT)
+	if err != nil {
+		return nil, err
+	}
+	defer l.Close()
+	clientConn, err := l.Accept()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &FlowStream{
+		hostPort:   hostPort,
+		clientConn: clientConn,
+	}, nil
+}
+
+func (p *FlowStream) ExportFlows(in <-chan []*flow.Record) {
+	//Create handler by opening Flow stream
+	for flowRecord := range in {
+		if len(flowRecord) > 0 {
+			for _, record := range flowRecord {
+				genericMap := decode.PBFlowToMap(flowToPB(record))
+				err := writeFlow(&genericMap, p.clientConn)
+				if err != nil {
+					plog.Fatal(err)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description

This PR add TCP flow stream exporter for cli.

## Dependencies

https://github.com/netobserv/network-observability-cli/pull/1

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
