### PR TITLE
NETOBSERV-1451: Bump ubi 9.3 / go 1.21

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@ linters:
     - unused
 linters-settings:
   stylecheck:
-    go: "1.20"
+    go: "1.21"
   gocritic:
     enabled-checks:
       - hugeParam

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILDPLATFORM=linux/amd64
 ARG TARGETARCH=amd64
 
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.20 as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.21 as builder
 
 ARG TARGETARCH
 ARG TARGETPLATFORM
@@ -27,7 +27,7 @@ COPY .mk/ .mk/
 RUN GOARCH=$TARGETARCH make compile
 
 # Create final image from minimal + built binary
-FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 WORKDIR /
 COPY --from=builder /opt/app-root/bin/netobserv-ebpf-agent .
 USER 65532:65532

--- a/examples/performance/Dockerfile_packet_counter
+++ b/examples/performance/Dockerfile_packet_counter
@@ -1,6 +1,6 @@
 # this file has to be built from the project root directory
 
-FROM golang:1.20 as builder
+FROM golang:1.21 as builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
