### PR TITLE
NETOBSERV-557: add eBPF agent metrics for troubleshooting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/netobserv/flowlogs-pipeline v0.1.11
 	github.com/netobserv/gopipes v0.3.0
 	github.com/paulbellamy/ratecounter v0.2.0
+	github.com/prometheus/client_golang v1.18.0
 	github.com/segmentio/kafka-go v0.4.47
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.8.4
@@ -87,7 +88,6 @@ require (
 	github.com/pion/udp v0.1.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.46.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -165,4 +165,12 @@ type Config struct {
 	PCAFilters string `env:"PCA_FILTER"`
 	// PCAServerPort is the port PCA Server starts at, when ENABLE_PCA variable is set to true.
 	PCAServerPort int `env:"PCA_SERVER_PORT" envDefault:"9990"`
+	// MetricsEnable enables http server to collect ebpf agent metrics, default is false.
+	MetricsEnable bool `env:"METRICS_ENABLE" envDefault:"false"`
+	// MetricsServerAddress is the address of the server that collects ebpf agent metrics.
+	MetricsServerAddress string `env:"METRICS_SERVER_ADDRESS"`
+	// MetricsPort is the port of the server that collects ebpf agent metrics.
+	MetricsPort int `env:"METRICS_SERVER_PORT" envDefault:"9090"`
+	// MetricsPrefix is the prefix of the metrics that are sent to the server.
+	MetricsPrefix string `env:"METRICS_PREFIX" envDefault:"ebpf_agent_"`
 }

--- a/pkg/agent/packets_agent.go
+++ b/pkg/agent/packets_agent.go
@@ -6,12 +6,14 @@ import (
 	"io"
 	"net"
 
-	"github.com/cilium/ebpf/perf"
 	"github.com/netobserv/gopipes/pkg/node"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/ebpf"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/exporter"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/flow"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/ifaces"
+
+	"github.com/cilium/ebpf/perf"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Packets reporting agent
@@ -39,7 +41,7 @@ type ebpfPacketFetcher interface {
 	io.Closer
 	Register(iface ifaces.Interface) error
 
-	LookupAndDeleteMap() map[int][]*byte
+	LookupAndDeleteMap(c prometheus.Counter) map[int][]*byte
 	ReadPerf() (perf.Record, error)
 }
 

--- a/pkg/exporter/grpc_proto.go
+++ b/pkg/exporter/grpc_proto.go
@@ -5,7 +5,10 @@ import (
 
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/flow"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/grpc"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/metrics"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/utils"
+
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 )
 
@@ -21,19 +24,25 @@ type GRPCProto struct {
 	// maxFlowsPerMessage limits the maximum number of flows per GRPC message.
 	// If a message contains more flows than this number, the GRPC message will be split into
 	// multiple messages.
-	maxFlowsPerMessage int
+	maxFlowsPerMessage            int
+	numberOfRecordsExportedByGRPC prometheus.Counter
+	exportedRecordsBatchSize      prometheus.Counter
+	errExportByGRPC               prometheus.Counter
 }
 
-func StartGRPCProto(hostIP string, hostPort int, maxFlowsPerMessage int) (*GRPCProto, error) {
+func StartGRPCProto(hostIP string, hostPort int, maxFlowsPerMessage int, m *metrics.Metrics) (*GRPCProto, error) {
 	clientConn, err := grpc.ConnectClient(hostIP, hostPort)
 	if err != nil {
 		return nil, err
 	}
 	return &GRPCProto{
-		hostIP:             hostIP,
-		hostPort:           hostPort,
-		clientConn:         clientConn,
-		maxFlowsPerMessage: maxFlowsPerMessage,
+		hostIP:                        hostIP,
+		hostPort:                      hostPort,
+		clientConn:                    clientConn,
+		maxFlowsPerMessage:            maxFlowsPerMessage,
+		numberOfRecordsExportedByGRPC: m.CreateNumberOfRecordsExportedByGRPC(),
+		exportedRecordsBatchSize:      m.CreateGRPCBatchSize(),
+		errExportByGRPC:               m.CreateErrorCanNotWriteToGRPC(),
 	}, nil
 }
 
@@ -43,14 +52,17 @@ func (g *GRPCProto) ExportFlows(input <-chan []*flow.Record) {
 	socket := utils.GetSocket(g.hostIP, g.hostPort)
 	log := glog.WithField("collector", socket)
 	for inputRecords := range input {
+		g.exportedRecordsBatchSize.Inc()
 		for _, pbRecords := range flowsToPB(inputRecords, g.maxFlowsPerMessage) {
 			log.Debugf("sending %d records", len(pbRecords.Entries))
 			if _, err := g.clientConn.Client().Send(context.TODO(), pbRecords); err != nil {
 				log.WithError(err).Error("couldn't send flow records to collector")
 			}
+			g.numberOfRecordsExportedByGRPC.Add(float64(len(pbRecords.Entries)))
 		}
 	}
 	if err := g.clientConn.Close(); err != nil {
 		log.WithError(err).Warn("couldn't close flow export client")
+		g.errExportByGRPC.Inc()
 	}
 }

--- a/pkg/exporter/grpc_proto_test.go
+++ b/pkg/exporter/grpc_proto_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/metrics"
 	test2 "github.com/netobserv/netobserv-ebpf-agent/pkg/test"
 
 	"github.com/mariomac/guara/pkg/test"
@@ -28,7 +29,12 @@ func TestIPv4GRPCProto_ExportFlows_AgentIP(t *testing.T) {
 	defer coll.Close()
 
 	// Start GRPCProto exporter stage
-	exporter, err := StartGRPCProto("127.0.0.1", port, 1000)
+	exporter, err := StartGRPCProto("127.0.0.1", port, 1000,
+		&metrics.Metrics{Settings: &metrics.Settings{
+			PromConnectionInfo: metrics.PromConnectionInfo{},
+			Prefix:             "",
+		},
+		})
 	require.NoError(t, err)
 
 	// Send some flows to the input of the exporter stage
@@ -70,7 +76,12 @@ func TestIPv6GRPCProto_ExportFlows_AgentIP(t *testing.T) {
 	defer coll.Close()
 
 	// Start GRPCProto exporter stage
-	exporter, err := StartGRPCProto("::1", port, 1000)
+	exporter, err := StartGRPCProto("::1", port, 1000,
+		&metrics.Metrics{Settings: &metrics.Settings{
+			PromConnectionInfo: metrics.PromConnectionInfo{},
+			Prefix:             "",
+		},
+		})
 	require.NoError(t, err)
 
 	// Send some flows to the input of the exporter stage
@@ -113,7 +124,12 @@ func TestGRPCProto_SplitLargeMessages(t *testing.T) {
 
 	const msgMaxLen = 10000
 	// Start GRPCProto exporter stage
-	exporter, err := StartGRPCProto("127.0.0.1", port, msgMaxLen)
+	exporter, err := StartGRPCProto("127.0.0.1", port, msgMaxLen,
+		&metrics.Metrics{Settings: &metrics.Settings{
+			PromConnectionInfo: metrics.PromConnectionInfo{},
+			Prefix:             "",
+		},
+		})
 	require.NoError(t, err)
 
 	// Send a message much longer than the limit length

--- a/pkg/flow/account_test.go
+++ b/pkg/flow/account_test.go
@@ -4,10 +4,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/ebpf"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/metrics"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/netobserv/netobserv-ebpf-agent/pkg/ebpf"
 )
 
 const timeout = 5 * time.Second
@@ -49,7 +50,7 @@ func TestEvict_MaxEntries(t *testing.T) {
 		return now
 	}, func() time.Duration {
 		return 1000
-	})
+	}, metrics.NewMetrics(&metrics.Settings{}))
 
 	// WHEN it starts accounting new records
 	inputs := make(chan *RawRecord, 20)
@@ -132,7 +133,7 @@ func TestEvict_Period(t *testing.T) {
 		return now
 	}, func() time.Duration {
 		return 1000
-	})
+	}, metrics.NewMetrics(&metrics.Settings{}))
 
 	// WHEN it starts accounting new records
 	inputs := make(chan *RawRecord, 20)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,237 @@
+package metrics
+
+import (
+	"errors"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+)
+
+type MetricDefinition struct {
+	Name   string
+	Help   string
+	Type   metricType
+	Labels []string
+}
+
+type PromConnectionInfo struct {
+	Address string
+	Port    int
+}
+
+type Settings struct {
+	PromConnectionInfo
+	Prefix string
+}
+
+type metricType string
+
+const (
+	TypeCounter   metricType = "counter"
+	TypeGauge     metricType = "gauge"
+	TypeHistogram metricType = "histogram"
+)
+
+var allMetrics = []MetricDefinition{}
+
+func defineMetric(name, help string, t metricType, labels ...string) MetricDefinition {
+	def := MetricDefinition{
+		Name:   name,
+		Help:   help,
+		Type:   t,
+		Labels: labels,
+	}
+	allMetrics = append(allMetrics, def)
+	return def
+}
+
+var (
+	hmapEvictionsTotal = defineMetric(
+		"hashmap_evictions_total",
+		"Number of hashmap evictions total",
+		TypeCounter,
+	)
+	userspaceNumberOfEvictionsTotal = defineMetric(
+		"userspace_number_of_evictions_total",
+		"Number of userspace evictions total",
+		TypeCounter,
+	)
+	numberOfevictedFlowsTotal = defineMetric(
+		"number_of_evicted_flows_total",
+		"Number of evicted flows Total",
+		TypeCounter,
+	)
+	numberofFlowsreceivedviaRingBufferTotal = defineMetric(
+		"number_of_flows_received_via_ring_buffer_total",
+		"Number of flows received via ring buffer total",
+		TypeCounter,
+	)
+	lookupAndDeleteMapDurationSeconds = defineMetric(
+		"lookup_and_delete_map_duration_seconds",
+		"Lookup and delete map duration seconds",
+		TypeHistogram,
+	)
+	numberOfWrittenRecordsTotal = defineMetric(
+		"number_of_written_records_total",
+		"Number of written records total",
+		TypeCounter,
+		"exporter",
+	)
+	exportedBatchSizeTotal = defineMetric(
+		"exported_batch_size_total",
+		"Exported batch size total",
+		TypeCounter,
+		"exporter",
+	)
+	samplingRateSeconds = defineMetric(
+		"sampling_rate_seconds",
+		"Sampling rate seconds",
+		TypeGauge,
+	)
+	errCanNotWriteRecordsTotal = defineMetric(
+		"err_can_not_write_records_total",
+		"error can not write records total",
+		TypeCounter,
+		"exporter",
+	)
+	errReadingRingBufferMapTotal = defineMetric(
+		"err_reading_ring_buffer_map_total",
+		"Error reading ring buffer map total",
+		TypeCounter,
+	)
+	errCanNotDeleteFlowEntriesTotal = defineMetric(
+		"err_can_not_delete_flow_entries_total",
+		"Error can not delete flow entries total",
+		TypeCounter,
+	)
+)
+
+func (def *MetricDefinition) mapLabels(labels []string) prometheus.Labels {
+	if len(labels) != len(def.Labels) {
+		logrus.Errorf("Could not map labels, length differ in def %s [%v / %v]", def.Name, def.Labels, labels)
+	}
+	labelsMap := prometheus.Labels{}
+	for i, label := range labels {
+		labelsMap[def.Labels[i]] = label
+	}
+	return labelsMap
+}
+
+func verifyMetricType(def *MetricDefinition, t metricType) {
+	if def.Type != t {
+		logrus.Panicf("operational metric %q is of type %q but is being registered as %q", def.Name, def.Type, t)
+	}
+}
+
+type Metrics struct {
+	Settings *Settings
+}
+
+func NewMetrics(settings *Settings) *Metrics {
+	return &Metrics{Settings: settings}
+}
+
+// register will register against the default registry. May panic or not depending on settings
+func (m *Metrics) register(c prometheus.Collector, name string) {
+	err := prometheus.DefaultRegisterer.Register(c)
+	if err != nil {
+		if errors.As(err, &prometheus.AlreadyRegisteredError{}) {
+			logrus.Warningf("metrics registration error [%s]: %v", name, err)
+		} else {
+			logrus.Panicf("metrics registration error [%s]: %v", name, err)
+		}
+	}
+}
+
+func (m *Metrics) NewCounter(def *MetricDefinition, labels ...string) prometheus.Counter {
+	verifyMetricType(def, TypeCounter)
+	fullName := m.Settings.Prefix + def.Name
+	c := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        fullName,
+		Help:        def.Help,
+		ConstLabels: def.mapLabels(labels),
+	})
+	m.register(c, fullName)
+	return c
+}
+
+func (m *Metrics) NewGauge(def *MetricDefinition, labels ...string) prometheus.Gauge {
+	verifyMetricType(def, TypeGauge)
+	fullName := m.Settings.Prefix + def.Name
+	c := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name:        fullName,
+		Help:        def.Help,
+		ConstLabels: def.mapLabels(labels),
+	})
+	m.register(c, fullName)
+	return c
+}
+
+func (m *Metrics) NewHistogram(def *MetricDefinition, buckets []float64, labels ...string) prometheus.Histogram {
+	verifyMetricType(def, TypeHistogram)
+	fullName := m.Settings.Prefix + def.Name
+	c := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:        fullName,
+		Help:        def.Help,
+		Buckets:     buckets,
+		ConstLabels: def.mapLabels(labels),
+	})
+	m.register(c, fullName)
+	return c
+}
+
+func (m *Metrics) CreateHashMapCounter() prometheus.Counter {
+	return m.NewCounter(&hmapEvictionsTotal)
+}
+
+func (m *Metrics) CreateUserSpaceEvictionCounter() prometheus.Counter {
+	return m.NewCounter(&userspaceNumberOfEvictionsTotal)
+}
+
+func (m *Metrics) CreateNumberOfEvictedFlows() prometheus.Counter {
+	return m.NewCounter(&numberOfevictedFlowsTotal)
+}
+
+func (m *Metrics) CreateNumberOfFlowsReceivedByRingBuffer() prometheus.Counter {
+	return m.NewCounter(&numberofFlowsreceivedviaRingBufferTotal)
+}
+
+func (m *Metrics) CreateTimeSpendInLookupAndDelete() prometheus.Histogram {
+	return m.NewHistogram(&lookupAndDeleteMapDurationSeconds, []float64{.001, .01, .1, 1, 10, 100, 1000, 10000})
+}
+
+func (m *Metrics) CreateNumberOfRecordsExportedByGRPC() prometheus.Counter {
+	return m.NewCounter(&numberOfWrittenRecordsTotal, "grpc")
+}
+
+func (m *Metrics) CreateGRPCBatchSize() prometheus.Counter {
+	return m.NewCounter(&exportedBatchSizeTotal, "grpc")
+}
+
+func (m *Metrics) CreateNumberOfRecordsExportedByKafka() prometheus.Counter {
+	return m.NewCounter(&numberOfWrittenRecordsTotal, "kafka")
+}
+
+func (m *Metrics) CreateKafkaBatchSize() prometheus.Counter {
+	return m.NewCounter(&exportedBatchSizeTotal, "kafka")
+}
+
+func (m *Metrics) CreateSamplingRate() prometheus.Gauge {
+	return m.NewGauge(&samplingRateSeconds)
+}
+
+func (m *Metrics) CreateErrorCanNotWriteToGRPC() prometheus.Counter {
+	return m.NewCounter(&errCanNotWriteRecordsTotal, "grpc")
+}
+
+func (m *Metrics) CreateErrorCanNotWriteToKafka() prometheus.Counter {
+	return m.NewCounter(&errCanNotWriteRecordsTotal, "kafka")
+}
+
+func (m *Metrics) CreateCanNotReadFromRingBufferMap() prometheus.Counter {
+	return m.NewCounter(&errReadingRingBufferMapTotal)
+}
+
+func (m *Metrics) CreateCanNotDeleteFlows() prometheus.Counter {
+	return m.NewCounter(&errCanNotDeleteFlowEntriesTotal)
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,69 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricsCreation(t *testing.T) {
+	// Create a dummy Settings struct
+	settings := &Settings{
+		PromConnectionInfo: PromConnectionInfo{
+			Address: "localhost",
+			Port:    9090,
+		},
+		Prefix: "test_prefix_",
+	}
+
+	// Create Metrics instance
+	metrics := NewMetrics(settings)
+
+	// Test Counter creation
+	counter := metrics.CreateHashMapCounter()
+	assert.NotNil(t, counter)
+
+	// Test Gauge creation
+	gauge := metrics.CreateNumberOfEvictedFlows()
+	assert.NotNil(t, gauge)
+
+	// Test Histogram creation
+	histogram := metrics.CreateTimeSpendInLookupAndDelete()
+	assert.NotNil(t, histogram)
+}
+
+func TestMapLabels(t *testing.T) {
+	labels := []string{"label1", "label2"}
+	metric := MetricDefinition{
+		Labels: labels,
+	}
+
+	mapped := metric.mapLabels([]string{"value1", "value2"})
+
+	if mapped["label1"] != "value1" {
+		t.Errorf("Expected label1 to map to value1 but got %s", mapped["label1"])
+	}
+
+	if mapped["label2"] != "value2" {
+		t.Errorf("Expected label2 to map to value2 but got %s", mapped["label2"])
+	}
+}
+
+func TestVerifyMetricType(t *testing.T) {
+	metric := MetricDefinition{
+		Name: "test",
+		Type: TypeCounter,
+	}
+
+	// Should not panic
+	verifyMetricType(&metric, TypeCounter)
+
+	// Should panic
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected verifyMetricType to panic but it did not")
+		}
+	}()
+
+	verifyMetricType(&metric, TypeGauge)
+}

--- a/pkg/prometheus/prom_server.go
+++ b/pkg/prometheus/prom_server.go
@@ -1,0 +1,98 @@
+package prometheus
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/metrics"
+
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	plog       = logrus.WithField("component", "prometheus")
+	maybePanic = plog.Fatalf
+)
+
+// InitializePrometheus starts the global Prometheus server, used for operational metrics and prom-encode stages if they don't override the server settings
+func InitializePrometheus(settings *metrics.Settings) *http.Server {
+	return StartServerAsync(settings, nil)
+}
+
+// StartServerAsync listens for prometheus resource usage requests
+func StartServerAsync(conn *metrics.Settings, registry *prom.Registry) *http.Server {
+	// create prometheus server for operational metrics
+	// if value of address is empty, then by default it will take 0.0.0.0
+	port := conn.Port
+	if port == 0 {
+		port = 9090
+	}
+	addr := fmt.Sprintf("%s:%v", conn.Address, port)
+	plog.Infof("StartServerAsync: addr = %s", addr)
+
+	httpServer := &http.Server{
+		Addr: addr,
+		// TLS clients must use TLS 1.2 or higher
+		TLSConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+	// The Handler function provides a default handler to expose metrics
+	// via an HTTP server. "/metrics" is the usual endpoint for that.
+	mux := http.NewServeMux()
+	if registry == nil {
+		mux.Handle("/metrics", promhttp.Handler())
+	} else {
+		mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	}
+	httpServer.Handler = mux
+	httpServer = defaultServer(httpServer)
+
+	go func() {
+		err := httpServer.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
+			maybePanic("error in http.ListenAndServe: %v", err)
+		}
+	}()
+
+	return httpServer
+}
+
+func defaultServer(srv *http.Server) *http.Server {
+	// defaults taken from https://bruinsslot.jp/post/go-secure-webserver/ can be overriden by caller
+	if srv.Handler != nil {
+		// No more than 2MB body
+		srv.Handler = http.MaxBytesHandler(srv.Handler, 2<<20)
+	} else {
+		plog.Warnf("Handler not yet set on server while securing defaults. Make sure a MaxByte middleware is used.")
+	}
+	if srv.ReadTimeout == 0 {
+		srv.ReadTimeout = 10 * time.Second
+	}
+	if srv.ReadHeaderTimeout == 0 {
+		srv.ReadHeaderTimeout = 5 * time.Second
+	}
+	if srv.WriteTimeout == 0 {
+		srv.WriteTimeout = 10 * time.Second
+	}
+	if srv.IdleTimeout == 0 {
+		srv.IdleTimeout = 120 * time.Second
+	}
+	if srv.MaxHeaderBytes == 0 {
+		srv.MaxHeaderBytes = 1 << 20 // 1MB
+	}
+	if srv.TLSConfig == nil {
+		srv.TLSConfig = &tls.Config{}
+	}
+	if srv.TLSConfig.MinVersion == 0 {
+		srv.TLSConfig.MinVersion = tls.VersionTLS13
+	}
+	// Disable http/2
+	srv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0)
+
+	return srv
+}

--- a/pkg/prometheus/prom_server_test.go
+++ b/pkg/prometheus/prom_server_test.go
@@ -1,0 +1,52 @@
+package prometheus
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/metrics"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartServerAsync(t *testing.T) {
+	// Create a mock metrics settings
+	mockSettings := &metrics.Settings{
+		PromConnectionInfo: metrics.PromConnectionInfo{
+			Address: "localhost",
+			Port:    9091,
+		},
+		Prefix: "test_prefix_",
+	}
+
+	// Start a mock server
+	server := StartServerAsync(mockSettings, nil)
+
+	// Create a test request to the /metrics endpoint
+	req, err := http.NewRequest("GET", "http://localhost:9091/metrics", nil)
+	assert.NoError(t, err, "Error creating request")
+
+	// Create a response recorder to record the response
+	rr := httptest.NewRecorder()
+
+	// Make the request to the mock server
+	go func() {
+		time.Sleep(100 * time.Millisecond) // Give the server some time to start
+		client := http.Client{}
+		_, err := client.Do(req)
+		assert.NoError(t, err, "Error making request to mock server")
+	}()
+
+	// Wait for the server to start
+	time.Sleep(200 * time.Millisecond)
+
+	// Simulate a shutdown request to stop the server
+	err = server.Shutdown(context.TODO())
+	assert.NoError(t, err, "Error shutting down server")
+
+	// Assert the response status code
+	assert.Equal(t, http.StatusOK, rr.Code, "Unexpected status code")
+}

--- a/pkg/test/tracer_fake.go
+++ b/pkg/test/tracer_fake.go
@@ -5,10 +5,12 @@ import (
 	"encoding/binary"
 	"time"
 
-	"github.com/cilium/ebpf/ringbuf"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/ebpf"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/flow"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/ifaces"
+
+	"github.com/cilium/ebpf/ringbuf"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // TracerFake fakes the kernel-side eBPF map structures for testing
@@ -34,7 +36,7 @@ func (m *TracerFake) Register(iface ifaces.Interface) error {
 	return nil
 }
 
-func (m *TracerFake) LookupAndDeleteMap() map[ebpf.BpfFlowId][]ebpf.BpfFlowMetrics {
+func (m *TracerFake) LookupAndDeleteMap(_ prometheus.Counter) map[ebpf.BpfFlowId][]ebpf.BpfFlowMetrics {
 	select {
 	case r := <-m.mapLookups:
 		return r


### PR DESCRIPTION
## Description

add promo metrics to eBPF agent with the ability to export metrics to promo Server

### unit-test
tested locally using standalone ebpf-agent
- `sudo LOG_LEVEL=debug FLOWS_TARGET_HOST=127.0.0.1 FLOWS_TARGET_PORT=9999   METRICS_PROMO_ENABLE="true" ./bin/netobserv-ebpf-agent`
- from another terminal `curl 127.0.0.1:9090/metrics | grep ebpf_agent`
results
```sh
:-- # TYPE ebpf_agent_err_can_not_delete_flow_entries counter
-ebpf_agent_err_can_not_delete_flow_entries{operational="errors while deleting flows"} 0
-:# HELP ebpf_agent_err_can_not_write_to_grpc Error can not write to GRPC
--# TYPE ebpf_agent_err_can_not_write_to_grpc counter
:-ebpf_agent_err_can_not_write_to_grpc{operational="err_export_by_grpc"} 0
- # HELP ebpf_agent_hashmap_evictions Number of hashmap evictions
8# TYPE ebpf_agent_hashmap_evictions counter
8ebpf_agent_hashmap_evictions{operational="hash map evictions"} 16
06# HELP ebpf_agent_number_of_evicted_flows Number of evicted flows
k# TYPE ebpf_agent_number_of_evicted_flows gauge

ebpf_agent_number_of_evicted_flows{operational="number of evicted flows"} 41
# HELP ebpf_agent_number_of_flows_received_via_ring_buffer Number of flows received via ring buffer
# TYPE ebpf_agent_number_of_flows_received_via_ring_buffer gauge
ebpf_agent_number_of_flows_received_via_ring_buffer{operational="number_of_flows_received"} 0
# HELP ebpf_agent_number_of_records_received_by_grpc Number of records received by GRPC
# TYPE ebpf_agent_number_of_records_received_by_grpc counter
ebpf_agent_number_of_records_received_by_grpc{operational="number_of_records_received_by_grpc"} 41
# HELP ebpf_agent_sampling_rate Sampling rate
# TYPE ebpf_agent_sampling_rate gauge
ebpf_agent_sampling_rate{operational="sampling rate"} 50
# HELP ebpf_agent_time_spent_in_lookup_and_delete_map Time spent in lookup and delete map
# TYPE ebpf_agent_time_spent_in_lookup_and_delete_map histogram
ebpf_agent_time_spent_in_lookup_and_delete_map_bucket{operational="time spent in lookup and delete",le="0.001"} 16
ebpf_agent_time_spent_in_lookup_and_delete_map_bucket{operational="time spent in lookup and delete",le="0.01"} 16
ebpf_agent_time_spent_in_lookup_and_delete_map_bucket{operational="time spent in lookup and delete",le="0.1"} 16
ebpf_agent_time_spent_in_lookup_and_delete_map_bucket{operational="time spent in lookup and delete",le="1"} 16
ebpf_agent_time_spent_in_lookup_and_delete_map_bucket{operational="time spent in lookup and delete",le="10"} 16
ebpf_agent_time_spent_in_lookup_and_delete_map_bucket{operational="time spent in lookup and delete",le="100"} 16
ebpf_agent_time_spent_in_lookup_and_delete_map_bucket{operational="time spent in lookup and delete",le="1000"} 16
ebpf_agent_time_spent_in_lookup_and_delete_map_bucket{operational="time spent in lookup and delete",le="10000"} 16
ebpf_agent_time_spent_in_lookup_and_delete_map_bucket{operational="time spent in lookup and delete",le="+Inf"} 16
ebpf_agent_time_spent_in_lookup_and_delete_map_sum{operational="time spent in lookup and delete"} 0.005711665
ebpf_agent_time_spent_in_lookup_and_delete_map_count{operational="time spent in lookup and delete"} 16
# HELP ebpf_agent_userspace_evictions Number of userspace evictions
# TYPE ebpf_agent_userspace_evictions counter
ebpf_agent_userspace_evictions{operational="user space evictions"} 0
```
## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
