### PR TITLE
NETOBSERV-1474: change dup mode to use list as the default

### DIFF
--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -85,9 +85,9 @@ type Config struct {
 	// If the value is not set, it will default to 2 * CacheActiveTimeout
 	DeduperFCExpiry time.Duration `env:"DEDUPER_FC_EXPIRY"`
 	// DeduperJustMark will just mark duplicates (boolean field) instead of dropping them.
-	DeduperJustMark bool `env:"DEDUPER_JUST_MARK"`
+	DeduperJustMark bool `env:"DEDUPER_JUST_MARK" envDefault:"false"`
 	// DeduperMerge will merge duplicated flows and generate list of interfaces and direction pairs
-	DeduperMerge bool `env:"DEDUPER_MERGE" envDefault:"false"`
+	DeduperMerge bool `env:"DEDUPER_MERGE" envDefault:"true"`
 	// Direction allows selecting which flows to trace according to its direction. Accepted values
 	// are "ingress", "egress" or "both" (default).
 	Direction string `env:"DIRECTION" envDefault:"both"`


### PR DESCRIPTION
## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
