### PR TITLE
Share errors counter across components

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -363,7 +363,7 @@ func buildKafkaExporter(cfg *Config) (node.TerminalFunc[[]*flow.Record], error) 
 		},
 		NumberOfRecordsExportedByKafka: m.CreateNumberOfRecordsExportedByKafka(),
 		ExportedRecordsBatchSize:       m.CreateKafkaBatchSize(),
-		ErrCanNotExportToKafka:         m.CreateErrorCanNotWriteToKafka(),
+		Errors:                         m.GetErrorsCounter(),
 	}).ExportFlows, nil
 }
 

--- a/pkg/exporter/kafka_proto_test.go
+++ b/pkg/exporter/kafka_proto_test.go
@@ -41,7 +41,7 @@ func TestProtoConversion(t *testing.T) {
 		Writer:                         &wc,
 		NumberOfRecordsExportedByKafka: m.CreateNumberOfRecordsExportedByKafka(),
 		ExportedRecordsBatchSize:       m.CreateKafkaBatchSize(),
-		ErrCanNotExportToKafka:         m.CreateErrorCanNotWriteToKafka(),
+		Errors:                         m.GetErrorsCounter(),
 	}
 	input := make(chan []*flow.Record, 11)
 	record := flow.Record{}

--- a/pkg/flow/tracer_map.go
+++ b/pkg/flow/tracer_map.go
@@ -29,7 +29,7 @@ type MapTracer struct {
 	hmapEvictionCounter        prometheus.Counter
 	numberOfEvictedFlows       prometheus.Counter
 	timeSpentinLookupAndDelete prometheus.Histogram
-	errCanNotDeleteflows       prometheus.Counter
+	errors                     *metrics.ErrorCounter
 }
 
 type mapFetcher interface {
@@ -47,7 +47,7 @@ func NewMapTracer(fetcher mapFetcher, evictionTimeout, staleEntriesEvictTimeout 
 		hmapEvictionCounter:        m.CreateHashMapCounter(),
 		numberOfEvictedFlows:       m.CreateNumberOfEvictedFlows(),
 		timeSpentinLookupAndDelete: m.CreateTimeSpendInLookupAndDelete(),
-		errCanNotDeleteflows:       m.CreateCanNotDeleteFlows(),
+		errors:                     m.GetErrorsCounter(),
 	}
 }
 
@@ -105,7 +105,7 @@ func (m *MapTracer) evictFlows(ctx context.Context, forceGC bool, forwardFlows c
 
 	var forwardingFlows []*Record
 	laterFlowNs := uint64(0)
-	flows := m.mapFetcher.LookupAndDeleteMap(m.errCanNotDeleteflows)
+	flows := m.mapFetcher.LookupAndDeleteMap(m.errors.WithValues("CannotDeleteFlows", ""))
 	elapsed := time.Since(currentTime)
 	for flowKey, flowMetrics := range flows {
 		aggregatedMetrics := m.aggregate(flowMetrics)


### PR DESCRIPTION
- All errors can now be found from metric "errors_total"
- Use error name and exporter as labels

![image](https://github.com/netobserv/netobserv-ebpf-agent/assets/2153442/59110947-bde1-4510-adea-427c48a71f5b)
