### PR TITLE
NETOBSERV-1533: refine metrics for dashboard creation

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cilium/ebpf/ringbuf"
 	"github.com/gavv/monotime"
-	"github.com/prometheus/client_golang/prometheus"
 	kafkago "github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/compress"
 	"github.com/sirupsen/logrus"
@@ -125,7 +124,7 @@ type ebpfFlowFetcher interface {
 	io.Closer
 	Register(iface ifaces.Interface) error
 
-	LookupAndDeleteMap(c prometheus.Counter) map[ebpf.BpfFlowId][]ebpf.BpfFlowMetrics
+	LookupAndDeleteMap(c *metrics.ErrorCounter) map[ebpf.BpfFlowId][]ebpf.BpfFlowMetrics
 	DeleteMapsStaleEntries(timeOut time.Duration)
 	ReadRingBuf() (ringbuf.Record, error)
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -126,7 +126,7 @@ type ebpfFlowFetcher interface {
 	io.Closer
 	Register(iface ifaces.Interface) error
 
-	LookupAndDeleteMap(c *metrics.ErrorCounter) map[ebpf.BpfFlowId][]ebpf.BpfFlowMetrics
+	LookupAndDeleteMap(*metrics.Metrics) map[ebpf.BpfFlowId][]ebpf.BpfFlowMetrics
 	DeleteMapsStaleEntries(timeOut time.Duration)
 	ReadRingBuf() (ringbuf.Record, error)
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -10,6 +10,7 @@ import (
 	test2 "github.com/mariomac/guara/pkg/test"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/ebpf"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/flow"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/metrics"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -204,6 +205,7 @@ func testAgent(t *testing.T, cfg *Config) *test.ExporterFake {
 	ebpfTracer := test.NewTracerFake()
 	export := test.NewExporterFake()
 	agent, err := flowsAgent(cfg,
+		metrics.NewMetrics(&metrics.Settings{}),
 		test.SliceInformerFake{
 			{Name: "foo", Index: 3},
 			{Name: "bar", Index: 4},

--- a/pkg/agent/packets_agent.go
+++ b/pkg/agent/packets_agent.go
@@ -11,9 +11,9 @@ import (
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/exporter"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/flow"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/ifaces"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/metrics"
 
 	"github.com/cilium/ebpf/perf"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Packets reporting agent
@@ -41,7 +41,7 @@ type ebpfPacketFetcher interface {
 	io.Closer
 	Register(iface ifaces.Interface) error
 
-	LookupAndDeleteMap(c prometheus.Counter) map[int][]*byte
+	LookupAndDeleteMap(c *metrics.ErrorCounter) map[int][]*byte
 	ReadPerf() (perf.Record, error)
 }
 

--- a/pkg/agent/packets_agent.go
+++ b/pkg/agent/packets_agent.go
@@ -41,7 +41,7 @@ type ebpfPacketFetcher interface {
 	io.Closer
 	Register(iface ifaces.Interface) error
 
-	LookupAndDeleteMap(c *metrics.ErrorCounter) map[int][]*byte
+	LookupAndDeleteMap(*metrics.Metrics) map[int][]*byte
 	ReadPerf() (perf.Record, error)
 }
 

--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -595,9 +595,6 @@ func NewPacketFetcher(
 		return nil, fmt.Errorf("loading and assigning BPF objects: %w", err)
 	}
 
-	if err != nil {
-		return nil, err
-	}
 	// read packets from igress+egress perf array
 	packets, err := perf.NewReader(objects.PacketRecord, os.Getpagesize())
 	if err != nil {

--- a/pkg/exporter/grpc_proto.go
+++ b/pkg/exporter/grpc_proto.go
@@ -56,7 +56,7 @@ func (g *GRPCProto) ExportFlows(input <-chan []*flow.Record) {
 		for _, pbRecords := range flowsToPB(inputRecords, g.maxFlowsPerMessage) {
 			log.Debugf("sending %d records", len(pbRecords.Entries))
 			if _, err := g.clientConn.Client().Send(context.TODO(), pbRecords); err != nil {
-				g.errors.WithValues("CantWriteMessage", "grpc").Inc()
+				g.errors.ForErrorAndExporter("CantWriteMessage", "grpc").Inc()
 				log.WithError(err).Error("couldn't send flow records to collector")
 			}
 			g.numberOfRecordsExportedByGRPC.Add(float64(len(pbRecords.Entries)))
@@ -64,6 +64,6 @@ func (g *GRPCProto) ExportFlows(input <-chan []*flow.Record) {
 	}
 	if err := g.clientConn.Close(); err != nil {
 		log.WithError(err).Warn("couldn't close flow export client")
-		g.errors.WithValues("CantCloseClient", "grpc").Inc()
+		g.errors.ForErrorAndExporter("CantCloseClient", "grpc").Inc()
 	}
 }

--- a/pkg/exporter/grpc_proto.go
+++ b/pkg/exporter/grpc_proto.go
@@ -14,6 +14,8 @@ import (
 
 var glog = logrus.WithField("component", "exporter/GRPCProto")
 
+const componentGRPC = "grpc"
+
 // GRPCProto flow exporter. Its ExportFlows method accepts slices of *flow.Record
 // by its input channel, converts them to *pbflow.Records instances, and submits
 // them to the collector.
@@ -24,10 +26,9 @@ type GRPCProto struct {
 	// maxFlowsPerMessage limits the maximum number of flows per GRPC message.
 	// If a message contains more flows than this number, the GRPC message will be split into
 	// multiple messages.
-	maxFlowsPerMessage            int
-	numberOfRecordsExportedByGRPC prometheus.Counter
-	exportedRecordsBatchSize      prometheus.Counter
-	errors                        *metrics.ErrorCounter
+	maxFlowsPerMessage int
+	metrics            *metrics.Metrics
+	batchCounter       prometheus.Counter
 }
 
 func StartGRPCProto(hostIP string, hostPort int, maxFlowsPerMessage int, m *metrics.Metrics) (*GRPCProto, error) {
@@ -36,13 +37,12 @@ func StartGRPCProto(hostIP string, hostPort int, maxFlowsPerMessage int, m *metr
 		return nil, err
 	}
 	return &GRPCProto{
-		hostIP:                        hostIP,
-		hostPort:                      hostPort,
-		clientConn:                    clientConn,
-		maxFlowsPerMessage:            maxFlowsPerMessage,
-		numberOfRecordsExportedByGRPC: m.CreateNumberOfRecordsExportedByGRPC(),
-		exportedRecordsBatchSize:      m.CreateGRPCBatchSize(),
-		errors:                        m.GetErrorsCounter(),
+		hostIP:             hostIP,
+		hostPort:           hostPort,
+		clientConn:         clientConn,
+		maxFlowsPerMessage: maxFlowsPerMessage,
+		metrics:            m,
+		batchCounter:       m.CreateBatchCounter(componentGRPC),
 	}, nil
 }
 
@@ -52,18 +52,19 @@ func (g *GRPCProto) ExportFlows(input <-chan []*flow.Record) {
 	socket := utils.GetSocket(g.hostIP, g.hostPort)
 	log := glog.WithField("collector", socket)
 	for inputRecords := range input {
-		g.exportedRecordsBatchSize.Inc()
+		g.metrics.EvictionCounter.WithSource(componentGRPC).Inc()
 		for _, pbRecords := range flowsToPB(inputRecords, g.maxFlowsPerMessage) {
 			log.Debugf("sending %d records", len(pbRecords.Entries))
 			if _, err := g.clientConn.Client().Send(context.TODO(), pbRecords); err != nil {
-				g.errors.ForErrorAndExporter("CantWriteMessage", "grpc").Inc()
+				g.metrics.Errors.WithErrorName(componentGRPC, "CannotWriteMessage").Inc()
 				log.WithError(err).Error("couldn't send flow records to collector")
 			}
-			g.numberOfRecordsExportedByGRPC.Add(float64(len(pbRecords.Entries)))
+			g.batchCounter.Inc()
+			g.metrics.EvictedFlowsCounter.WithSource(componentGRPC).Add(float64(len(pbRecords.Entries)))
 		}
 	}
 	if err := g.clientConn.Close(); err != nil {
 		log.WithError(err).Warn("couldn't close flow export client")
-		g.errors.ForErrorAndExporter("CantCloseClient", "grpc").Inc()
+		g.metrics.Errors.WithErrorName(componentGRPC, "CannotCloseClient").Inc()
 	}
 }

--- a/pkg/exporter/grpc_proto_test.go
+++ b/pkg/exporter/grpc_proto_test.go
@@ -29,12 +29,7 @@ func TestIPv4GRPCProto_ExportFlows_AgentIP(t *testing.T) {
 	defer coll.Close()
 
 	// Start GRPCProto exporter stage
-	exporter, err := StartGRPCProto("127.0.0.1", port, 1000,
-		&metrics.Metrics{Settings: &metrics.Settings{
-			PromConnectionInfo: metrics.PromConnectionInfo{},
-			Prefix:             "",
-		},
-		})
+	exporter, err := StartGRPCProto("127.0.0.1", port, 1000, metrics.NewMetrics(&metrics.Settings{}))
 	require.NoError(t, err)
 
 	// Send some flows to the input of the exporter stage
@@ -76,12 +71,7 @@ func TestIPv6GRPCProto_ExportFlows_AgentIP(t *testing.T) {
 	defer coll.Close()
 
 	// Start GRPCProto exporter stage
-	exporter, err := StartGRPCProto("::1", port, 1000,
-		&metrics.Metrics{Settings: &metrics.Settings{
-			PromConnectionInfo: metrics.PromConnectionInfo{},
-			Prefix:             "",
-		},
-		})
+	exporter, err := StartGRPCProto("::1", port, 1000, metrics.NewMetrics(&metrics.Settings{}))
 	require.NoError(t, err)
 
 	// Send some flows to the input of the exporter stage
@@ -124,12 +114,7 @@ func TestGRPCProto_SplitLargeMessages(t *testing.T) {
 
 	const msgMaxLen = 10000
 	// Start GRPCProto exporter stage
-	exporter, err := StartGRPCProto("127.0.0.1", port, msgMaxLen,
-		&metrics.Metrics{Settings: &metrics.Settings{
-			PromConnectionInfo: metrics.PromConnectionInfo{},
-			Prefix:             "",
-		},
-		})
+	exporter, err := StartGRPCProto("127.0.0.1", port, msgMaxLen, metrics.NewMetrics(&metrics.Settings{}))
 	require.NoError(t, err)
 
 	// Send a message much longer than the limit length

--- a/pkg/exporter/kafka_proto.go
+++ b/pkg/exporter/kafka_proto.go
@@ -53,7 +53,7 @@ func (kp *KafkaProto) batchAndSubmit(records []*flow.Record) {
 		pbBytes, err := proto.Marshal(flowToPB(record))
 		if err != nil {
 			klog.WithError(err).Debug("can't encode protobuf message. Ignoring")
-			kp.Errors.WithValues("CantEncodeMessage", "kafka").Inc()
+			kp.Errors.ForErrorAndExporter("CantEncodeMessage", "kafka").Inc()
 			continue
 		}
 		msgs = append(msgs, kafkago.Message{Value: pbBytes, Key: getFlowKey(record)})
@@ -62,7 +62,7 @@ func (kp *KafkaProto) batchAndSubmit(records []*flow.Record) {
 
 	if err := kp.Writer.WriteMessages(context.TODO(), msgs...); err != nil {
 		klog.WithError(err).Error("can't write messages into Kafka")
-		kp.Errors.WithValues("CantWriteMessage", "kafka").Inc()
+		kp.Errors.ForErrorAndExporter("CantWriteMessage", "kafka").Inc()
 	}
 	kp.NumberOfRecordsExportedByKafka.Add(float64(len(records)))
 }

--- a/pkg/exporter/kafka_proto.go
+++ b/pkg/exporter/kafka_proto.go
@@ -6,13 +6,14 @@ import (
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/flow"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/metrics"
 
-	"github.com/prometheus/client_golang/prometheus"
 	kafkago "github.com/segmentio/kafka-go"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
 )
 
 var klog = logrus.WithField("component", "exporter/KafkaProto")
+
+const componentKafka = "kafka"
 
 type kafkaWriter interface {
 	WriteMessages(ctx context.Context, msgs ...kafkago.Message) error
@@ -21,10 +22,8 @@ type kafkaWriter interface {
 // KafkaProto exports flows over Kafka, encoded as a protobuf that is understandable by the
 // Flowlogs-Pipeline collector
 type KafkaProto struct {
-	Writer                         kafkaWriter
-	NumberOfRecordsExportedByKafka prometheus.Counter
-	ExportedRecordsBatchSize       prometheus.Counter
-	Errors                         *metrics.ErrorCounter
+	Writer  kafkaWriter
+	Metrics *metrics.Metrics
 }
 
 func (kp *KafkaProto) ExportFlows(input <-chan []*flow.Record) {
@@ -53,18 +52,18 @@ func (kp *KafkaProto) batchAndSubmit(records []*flow.Record) {
 		pbBytes, err := proto.Marshal(flowToPB(record))
 		if err != nil {
 			klog.WithError(err).Debug("can't encode protobuf message. Ignoring")
-			kp.Errors.ForErrorAndExporter("CantEncodeMessage", "kafka").Inc()
+			kp.Metrics.Errors.WithErrorName(componentKafka, "CannotEncodeMessage").Inc()
 			continue
 		}
 		msgs = append(msgs, kafkago.Message{Value: pbBytes, Key: getFlowKey(record)})
-		kp.ExportedRecordsBatchSize.Add(float64(len(pbBytes)))
 	}
 
 	if err := kp.Writer.WriteMessages(context.TODO(), msgs...); err != nil {
 		klog.WithError(err).Error("can't write messages into Kafka")
-		kp.Errors.ForErrorAndExporter("CantWriteMessage", "kafka").Inc()
+		kp.Metrics.Errors.WithErrorName(componentKafka, "CannotWriteMessage").Inc()
 	}
-	kp.NumberOfRecordsExportedByKafka.Add(float64(len(records)))
+	kp.Metrics.EvictionCounter.WithSource(componentKafka).Inc()
+	kp.Metrics.EvictedFlowsCounter.WithSource(componentKafka).Add(float64(len(records)))
 }
 
 type JSONRecord struct {

--- a/pkg/exporter/kafka_proto_test.go
+++ b/pkg/exporter/kafka_proto_test.go
@@ -31,18 +31,9 @@ func ByteArrayFromNetIP(netIP net.IP) []uint8 {
 
 func TestProtoConversion(t *testing.T) {
 	wc := writerCapturer{}
-	m := metrics.NewMetrics(
-		&metrics.Settings{
-			PromConnectionInfo: metrics.PromConnectionInfo{},
-			Prefix:             "",
-		})
+	m := metrics.NewMetrics(&metrics.Settings{})
 
-	kj := KafkaProto{
-		Writer:                         &wc,
-		NumberOfRecordsExportedByKafka: m.CreateNumberOfRecordsExportedByKafka(),
-		ExportedRecordsBatchSize:       m.CreateKafkaBatchSize(),
-		Errors:                         m.GetErrorsCounter(),
-	}
+	kj := KafkaProto{Writer: &wc, Metrics: m}
 	input := make(chan []*flow.Record, 11)
 	record := flow.Record{}
 	record.Id.EthProtocol = 3

--- a/pkg/flow/deduper_test.go
+++ b/pkg/flow/deduper_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/ebpf"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/metrics"
 )
 
 var (
@@ -70,7 +71,7 @@ func TestDedupe(t *testing.T) {
 	input := make(chan []*Record, 100)
 	output := make(chan []*Record, 100)
 
-	go Dedupe(time.Minute, false, false, interfaceNamer)(input, output)
+	go Dedupe(time.Minute, false, false, interfaceNamer, metrics.NewMetrics(&metrics.Settings{}))(input, output)
 
 	input <- []*Record{
 		oneIf2,   // record 1 at interface 2: should be accepted
@@ -108,7 +109,7 @@ func TestDedupe_EvictFlows(t *testing.T) {
 	input := make(chan []*Record, 100)
 	output := make(chan []*Record, 100)
 
-	go Dedupe(15*time.Second, false, false, interfaceNamer)(input, output)
+	go Dedupe(15*time.Second, false, false, interfaceNamer, metrics.NewMetrics(&metrics.Settings{}))(input, output)
 
 	// Should only accept records 1 and 2, at interface 1
 	input <- []*Record{oneIf1, twoIf1, oneIf2}
@@ -143,7 +144,7 @@ func TestDedupeMerge(t *testing.T) {
 	input := make(chan []*Record, 100)
 	output := make(chan []*Record, 100)
 
-	go Dedupe(time.Minute, false, true, interfaceNamer)(input, output)
+	go Dedupe(time.Minute, false, true, interfaceNamer, metrics.NewMetrics(&metrics.Settings{}))(input, output)
 
 	input <- []*Record{
 		oneIf2, // record 1 at interface 2: should be accepted

--- a/pkg/flow/limiter.go
+++ b/pkg/flow/limiter.go
@@ -30,7 +30,7 @@ func (c *CapacityLimiter) Limit(in <-chan []*Record, out chan<- []*Record) {
 		if len(out) < cap(out) || cap(out) == 0 {
 			out <- i
 		} else {
-			c.metrics.DroppedFlowsCounter.WithSourceAndReason("limiter", "limit reached").Add(float64(len(i)))
+			c.metrics.DroppedFlowsCounter.WithSourceAndReason("limiter", "full").Add(float64(len(i)))
 			c.droppedFlows += len(i)
 		}
 	}

--- a/pkg/flow/limiter.go
+++ b/pkg/flow/limiter.go
@@ -3,6 +3,7 @@ package flow
 import (
 	"time"
 
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/metrics"
 	"github.com/sirupsen/logrus"
 )
 
@@ -16,6 +17,11 @@ var cllog = logrus.WithField("component", "capacity.Limiter")
 // log a message about the number of lost flows.
 type CapacityLimiter struct {
 	droppedFlows int
+	metrics      *metrics.Metrics
+}
+
+func NewCapacityLimiter(m *metrics.Metrics) *CapacityLimiter {
+	return &CapacityLimiter{metrics: m}
 }
 
 func (c *CapacityLimiter) Limit(in <-chan []*Record, out chan<- []*Record) {
@@ -24,6 +30,7 @@ func (c *CapacityLimiter) Limit(in <-chan []*Record, out chan<- []*Record) {
 		if len(out) < cap(out) || cap(out) == 0 {
 			out <- i
 		} else {
+			c.metrics.DroppedFlowsCounter.WithSourceAndReason("limiter", "limit reached").Add(float64(len(i)))
 			c.droppedFlows += len(i)
 		}
 	}

--- a/pkg/flow/limiter_test.go
+++ b/pkg/flow/limiter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/netobserv/gopipes/pkg/node"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,7 +72,7 @@ func capacityLimiterPipe() (in chan<- []*Record, out <-chan []*Record) {
 			initOut <- i
 		}
 	})
-	limiter := node.AsMiddle((&CapacityLimiter{}).Limit)
+	limiter := node.AsMiddle((NewCapacityLimiter(metrics.NewMetrics(&metrics.Settings{}))).Limit)
 	term := node.AsTerminal(func(termIn <-chan []*Record) {
 		for i := range termIn {
 			outCh <- i

--- a/pkg/flow/tracer_map.go
+++ b/pkg/flow/tracer_map.go
@@ -31,7 +31,7 @@ type MapTracer struct {
 }
 
 type mapFetcher interface {
-	LookupAndDeleteMap(counter *metrics.ErrorCounter) map[ebpf.BpfFlowId][]ebpf.BpfFlowMetrics
+	LookupAndDeleteMap(*metrics.Metrics) map[ebpf.BpfFlowId][]ebpf.BpfFlowMetrics
 	DeleteMapsStaleEntries(timeOut time.Duration)
 }
 
@@ -101,7 +101,7 @@ func (m *MapTracer) evictFlows(ctx context.Context, forceGC bool, forwardFlows c
 
 	var forwardingFlows []*Record
 	laterFlowNs := uint64(0)
-	flows := m.mapFetcher.LookupAndDeleteMap(m.metrics.Errors)
+	flows := m.mapFetcher.LookupAndDeleteMap(m.metrics)
 	elapsed := time.Since(currentTime)
 	for flowKey, flowMetrics := range flows {
 		aggregatedMetrics := m.aggregate(flowMetrics)

--- a/pkg/flow/tracer_ringbuf.go
+++ b/pkg/flow/tracer_ringbuf.go
@@ -22,11 +22,10 @@ var rtlog = logrus.WithField("component", "flow.RingBufTracer")
 // added in the eBPF kernel space due to the map being full or busy) and submits them to the
 // userspace Aggregator map
 type RingBufTracer struct {
-	mapFlusher          mapFlusher
-	ringBuffer          ringBufReader
-	stats               stats
-	evictedFlowsCounter *metrics.EvictionCounter
-	errors              *metrics.ErrorCounter
+	mapFlusher mapFlusher
+	ringBuffer ringBufReader
+	stats      stats
+	metrics    *metrics.Metrics
 }
 
 type ringBufReader interface {
@@ -47,11 +46,10 @@ type mapFlusher interface {
 
 func NewRingBufTracer(reader ringBufReader, flusher mapFlusher, logTimeout time.Duration, m *metrics.Metrics) *RingBufTracer {
 	return &RingBufTracer{
-		mapFlusher:          flusher,
-		ringBuffer:          reader,
-		stats:               stats{loggingTimeout: logTimeout},
-		evictedFlowsCounter: m.GetEvictedFlowsCounter(),
-		errors:              m.GetErrorsCounter(),
+		mapFlusher: flusher,
+		ringBuffer: reader,
+		stats:      stats{loggingTimeout: logTimeout},
+		metrics:    m,
 	}
 }
 
@@ -80,13 +78,13 @@ func (m *RingBufTracer) TraceLoop(ctx context.Context) node.StartFunc[*RawRecord
 func (m *RingBufTracer) listenAndForwardRingBuffer(debugging bool, forwardCh chan<- *RawRecord) error {
 	event, err := m.ringBuffer.ReadRingBuf()
 	if err != nil {
-		m.errors.ForError("CantReadRingbuffer").Inc()
+		m.metrics.Errors.WithErrorName("ringbuffer", "CannotReadRingbuffer").Inc()
 		return fmt.Errorf("reading from ring buffer: %w", err)
 	}
 	// Parses the ringbuf event entry into an Event structure.
 	readFlow, err := ReadFrom(bytes.NewBuffer(event.RawSample))
 	if err != nil {
-		m.errors.ForError("CantParseRingbuffer").Inc()
+		m.metrics.Errors.WithErrorName("ringbuffer", "CannotParseRingbuffer").Inc()
 		return fmt.Errorf("parsing data received from the ring buffer: %w", err)
 	}
 	mapFullError := readFlow.Metrics.Errno == uint8(syscall.E2BIG)
@@ -100,7 +98,7 @@ func (m *RingBufTracer) listenAndForwardRingBuffer(debugging bool, forwardCh cha
 		m.mapFlusher.Flush("full")
 		reason = "mapfull"
 	}
-	m.evictedFlowsCounter.ForSourceAndReason("ringbuffer", reason).Inc()
+	m.metrics.EvictedFlowsCounter.WithSourceAndReason("ringbuffer", reason).Inc()
 	// Will need to send it to accounter anyway to account regardless of complete/ongoing flow
 	forwardCh <- readFlow
 	return nil

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -60,6 +60,13 @@ var (
 		"source",
 		"reason",
 	)
+	evictedPktTotal = defineMetric(
+		"evicted_packets_total",
+		"Number of evicted packets",
+		TypeCounter,
+		"source",
+		"reason",
+	)
 	lookupAndDeleteMapDurationSeconds = defineMetric(
 		"lookup_and_delete_map_duration_seconds",
 		"Lookup and delete map duration in seconds",
@@ -119,11 +126,12 @@ type Metrics struct {
 	Settings *Settings
 
 	// Shared metrics:
-	EvictionCounter     *EvictionCounter
-	EvictedFlowsCounter *EvictionCounter
-	DroppedFlowsCounter *EvictionCounter
-	BufferSizeGauge     *BufferSizeGauge
-	Errors              *ErrorCounter
+	EvictionCounter       *EvictionCounter
+	EvictedFlowsCounter   *EvictionCounter
+	EvictedPacketsCounter *EvictionCounter
+	DroppedFlowsCounter   *EvictionCounter
+	BufferSizeGauge       *BufferSizeGauge
+	Errors                *ErrorCounter
 }
 
 func NewMetrics(settings *Settings) *Metrics {
@@ -132,6 +140,7 @@ func NewMetrics(settings *Settings) *Metrics {
 	}
 	m.EvictionCounter = &EvictionCounter{vec: m.NewCounterVec(&evictionsTotal)}
 	m.EvictedFlowsCounter = &EvictionCounter{vec: m.NewCounterVec(&evictedFlowsTotal)}
+	m.EvictedPacketsCounter = &EvictionCounter{vec: m.NewCounterVec(&evictedPktTotal)}
 	m.DroppedFlowsCounter = &EvictionCounter{vec: m.NewCounterVec(&droppedFlows)}
 	m.BufferSizeGauge = &BufferSizeGauge{vec: m.NewGaugeVec(&bufferSize)}
 	m.Errors = &ErrorCounter{vec: m.NewCounterVec(&errorsCounter)}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -20,11 +20,11 @@ func TestMetricsCreation(t *testing.T) {
 	metrics := NewMetrics(settings)
 
 	// Test Counter creation
-	counter := metrics.CreateHashMapCounter()
+	counter := metrics.CreateGRPCBatchSize()
 	assert.NotNil(t, counter)
 
 	// Test Gauge creation
-	gauge := metrics.CreateNumberOfEvictedFlows()
+	gauge := metrics.CreateSamplingRate()
 	assert.NotNil(t, gauge)
 
 	// Test Histogram creation

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -20,7 +20,7 @@ func TestMetricsCreation(t *testing.T) {
 	metrics := NewMetrics(settings)
 
 	// Test Counter creation
-	counter := metrics.CreateGRPCBatchSize()
+	counter := metrics.CreateBatchCounter("grpc")
 	assert.NotNil(t, counter)
 
 	// Test Gauge creation

--- a/pkg/test/tracer_fake.go
+++ b/pkg/test/tracer_fake.go
@@ -8,9 +8,9 @@ import (
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/ebpf"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/flow"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/ifaces"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/metrics"
 
 	"github.com/cilium/ebpf/ringbuf"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // TracerFake fakes the kernel-side eBPF map structures for testing
@@ -36,7 +36,7 @@ func (m *TracerFake) Register(iface ifaces.Interface) error {
 	return nil
 }
 
-func (m *TracerFake) LookupAndDeleteMap(_ prometheus.Counter) map[ebpf.BpfFlowId][]ebpf.BpfFlowMetrics {
+func (m *TracerFake) LookupAndDeleteMap(_ *metrics.ErrorCounter) map[ebpf.BpfFlowId][]ebpf.BpfFlowMetrics {
 	select {
 	case r := <-m.mapLookups:
 		return r

--- a/pkg/test/tracer_fake.go
+++ b/pkg/test/tracer_fake.go
@@ -36,7 +36,7 @@ func (m *TracerFake) Register(iface ifaces.Interface) error {
 	return nil
 }
 
-func (m *TracerFake) LookupAndDeleteMap(_ *metrics.ErrorCounter) map[ebpf.BpfFlowId][]ebpf.BpfFlowMetrics {
+func (m *TracerFake) LookupAndDeleteMap(_ *metrics.Metrics) map[ebpf.BpfFlowId][]ebpf.BpfFlowMetrics {
 	select {
 	case r := <-m.mapLookups:
 		return r


### PR DESCRIPTION
- Use just two shared metrics for eviction counters: on for eviction events and one for flows; shared across ringbuf/map implementations and labelled as such
- Report more errors via metrics
