### PR TITLE
NETOBSERV-1535: ebpf agent cannot change netns for a process with muliple goroutines

### DIFF
--- a/scripts/agent.yml
+++ b/scripts/agent.yml
@@ -50,8 +50,15 @@ spec:
             - name: bpf-kernel-debug
               mountPath: /sys/kernel/debug
               mountPropagation: Bidirectional
+            - name: netns
+              mountPath: /var/run/netns
+              mountPropagation: Bidirectional
       volumes:
         - name: bpf-kernel-debug
           hostPath:
             path: /sys/kernel/debug
+            type: Directory
+        - name: netns
+          hostPath:
+            path: /var/run/netns
             type: Directory

--- a/scripts/kind-cluster.sh
+++ b/scripts/kind-cluster.sh
@@ -16,6 +16,9 @@ networking:
     ipFamily: $IP_FAMILY
 nodes:
 - role: control-plane
+  extraMounts:
+  - hostPath: /var/run/netns
+    containerPath: /var/run/netns
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration
@@ -29,7 +32,13 @@ nodes:
         extraArgs:
             v: "5"
 - role: worker
+  extraMounts:
+  - hostPath: /var/run/netns
+    containerPath: /var/run/netns
 - role: worker
+  extraMounts:
+  - hostPath: /var/run/netns
+    containerPath: /var/run/netns
 EOF
 }
 


### PR DESCRIPTION
## Description
the current implementation tries to detect when new netns is created then register for netlink events for that new netns however it fails because
```sh
 EINVAL The caller is multithreaded and tried to join a new user
              namespace.
```
the work around is to reload ebpf agent when new netns is detected
there is also possible solution switching interfaces notification to different netlink package  https://github.com/mdlayher/netlink but this is more risk and add lots of complexity
Signed-off-by: Mohamed Mahmoud <mmahmoud@redhat.com>

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
