### PR TITLE
NETOBSERV-1532: add TLS support to ebpf agent metrics config

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -156,6 +156,12 @@ func FlowsAgent(cfg *Config) (*Flows, error) {
 		},
 		Prefix: cfg.MetricsPrefix,
 	}
+	if cfg.MetricsTLSCertPath != "" && cfg.MetricsTLSKeyPath != "" {
+		metricsSettings.PromConnectionInfo.TLS = &metrics.PromTLS{
+			CertPath: cfg.MetricsTLSCertPath,
+			KeyPath:  cfg.MetricsTLSKeyPath,
+		}
+	}
 	m := metrics.NewMetrics(metricsSettings)
 
 	// configure selected exporter

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -175,6 +175,10 @@ type Config struct {
 	MetricsServerAddress string `env:"METRICS_SERVER_ADDRESS"`
 	// MetricsPort is the port of the server that collects ebpf agent metrics.
 	MetricsPort int `env:"METRICS_SERVER_PORT" envDefault:"9090"`
+	// MetricsTLSCertPath is the path to the server certificate for TLS connections
+	MetricsTLSCertPath string `env:"METRICS_TLS_CERT_PATH"`
+	// MetricsTLSKeyPath is the path to the server private key for TLS connections
+	MetricsTLSKeyPath string `env:"METRICS_TLS_KEY_PATH"`
 	// MetricsPrefix is the prefix of the metrics that are sent to the server.
 	MetricsPrefix string `env:"METRICS_PREFIX" envDefault:"ebpf_agent_"`
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -14,9 +14,15 @@ type MetricDefinition struct {
 	Labels []string
 }
 
+type PromTLS struct {
+	CertPath string
+	KeyPath  string
+}
+
 type PromConnectionInfo struct {
 	Address string
 	Port    int
+	TLS     *PromTLS
 }
 
 type Settings struct {

--- a/pkg/prometheus/prom_server.go
+++ b/pkg/prometheus/prom_server.go
@@ -53,7 +53,12 @@ func StartServerAsync(conn *metrics.Settings, registry *prom.Registry) *http.Ser
 	httpServer = defaultServer(httpServer)
 
 	go func() {
-		err := httpServer.ListenAndServe()
+		var err error
+		if conn.TLS != nil {
+			err = httpServer.ListenAndServeTLS(conn.TLS.CertPath, conn.TLS.KeyPath)
+		} else {
+			err = httpServer.ListenAndServe()
+		}
 		if err != nil && err != http.ErrServerClosed {
 			maybePanic("error in http.ListenAndServe: %v", err)
 		}


### PR DESCRIPTION
## Description
Add the ability to use TLS for the metrics server,

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
