### PR TITLE
Codecov: remove token, turn off CI failure

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,10 +1,8 @@
 name: Pull request checks
 
 on:
-  push:
-    branches: [ 'main', 'release-*' ]
   pull_request:
-    branches: [ 'main', 'release-*' ]
+    branches: [ '*' ]
 
 jobs:
   test:
@@ -30,10 +28,8 @@ jobs:
     - name: Report coverage
       if: ${{ matrix.go == '1.21' }}
       uses: codecov/codecov-action@v4
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         files: ./cover.out
         flags: unittests
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         verbose: true


### PR DESCRIPTION
See also: netobserv/network-observability-console-plugin#531

Also, align the workflow file with other repos
