### PR TITLE
NETOBSERV-1697: Add retry around netlinkSubscribeAt

### DIFF
--- a/pkg/ifaces/poller_test.go
+++ b/pkg/ifaces/poller_test.go
@@ -19,7 +19,7 @@ func TestPoller(t *testing.T) {
 	// fake net.Interfaces implementation that returns two different sets of
 	// interfaces on successive invocations
 	firstInvocation := true
-	var fakeInterfaces = func() ([]Interface, error) {
+	var fakeInterfaces = func(handle netns.NsHandle) ([]Interface, error) {
 		if firstInvocation {
 			firstInvocation = false
 			return []Interface{{"foo", 1, netns.None()}, {"bar", 2, netns.None()}}, nil

--- a/pkg/ifaces/registerer_test.go
+++ b/pkg/ifaces/registerer_test.go
@@ -17,7 +17,7 @@ func TestRegisterer(t *testing.T) {
 	watcher := NewWatcher(10)
 	registry := NewRegisterer(watcher, 10)
 	// mock net.Interfaces and linkSubscriber to control which interfaces are discovered
-	watcher.interfaces = func() ([]Interface, error) {
+	watcher.interfaces = func(handle netns.NsHandle) ([]Interface, error) {
 		return []Interface{{"foo", 1, netns.None()}, {"bar", 2, netns.None()}, {"baz", 3, netns.None()}}, nil
 	}
 	inputLinks := make(chan netlink.LinkUpdate, 10)

--- a/pkg/ifaces/watcher_test.go
+++ b/pkg/ifaces/watcher_test.go
@@ -19,7 +19,7 @@ func TestWatcher(t *testing.T) {
 
 	watcher := NewWatcher(10)
 	// mock net.Interfaces and linkSubscriber to control which interfaces are discovered
-	watcher.interfaces = func() ([]Interface, error) {
+	watcher.interfaces = func(handle netns.NsHandle) ([]Interface, error) {
 		return []Interface{{"foo", 1, netns.None()}, {"bar", 2, netns.None()}, {"baz", 3, netns.None()}}, nil
 	}
 	inputLinks := make(chan netlink.LinkUpdate, 10)


### PR DESCRIPTION
## Description

while netns is getting it was noticed the associated netnsHandle keep changing for sometime then become stable and at that point `netlinkSubscribeAt` will succeed

so added retry loop and avoid the early creation of netnshandle till things become more stable
## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
