### PR TITLE
NETOBSERV-1743: handle file exits error using TCx hooks and update FC

### DIFF
--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -230,7 +230,12 @@ func (m *FlowFetcher) AttachTCX(iface ifaces.Interface) error {
 			Interface: iface.Index,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to attach TCX egress: %w", err)
+			if errors.Is(err, fs.ErrExist) {
+				// The interface already has a TCX egress hook
+				log.WithField("iface", iface.Name).Debug("interface already has a TCX egress hook ignore")
+			} else {
+				return fmt.Errorf("failed to attach TCX egress: %w", err)
+			}
 		}
 		m.egressTCXLink[iface] = egrLink
 		ilog.WithField("interface", iface.Name).Debug("successfully attach egressTCX hook")
@@ -243,7 +248,12 @@ func (m *FlowFetcher) AttachTCX(iface ifaces.Interface) error {
 			Interface: iface.Index,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to attach TCX ingress: %w", err)
+			if errors.Is(err, fs.ErrExist) {
+				// The interface already has a TCX ingress hook
+				log.WithField("iface", iface.Name).Debug("interface already has a TCX ingress hook ignore")
+			} else {
+				return fmt.Errorf("failed to attach TCX ingress: %w", err)
+			}
 		}
 		m.ingressTCXLink[iface] = ingLink
 		ilog.WithField("interface", iface.Name).Debug("successfully attach ingressTCX hook")
@@ -928,7 +938,12 @@ func (p *PacketFetcher) AttachTCX(iface ifaces.Interface) error {
 			Interface: iface.Index,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to attach PCA TCX egress: %w", err)
+			if errors.Is(err, fs.ErrExist) {
+				// The interface already has a TCX egress hook
+				log.WithField("iface", iface.Name).Debug("interface already has a TCX PCA egress hook ignore")
+			} else {
+				return fmt.Errorf("failed to attach PCA TCX egress: %w", err)
+			}
 		}
 		p.egressTCXLink[iface] = egrLink
 		ilog.WithField("interface", iface.Name).Debug("successfully attach PCA egressTCX hook")
@@ -941,7 +956,12 @@ func (p *PacketFetcher) AttachTCX(iface ifaces.Interface) error {
 			Interface: iface.Index,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to attach PCA TCX ingress: %w", err)
+			if errors.Is(err, fs.ErrExist) {
+				// The interface already has a TCX ingress hook
+				log.WithField("iface", iface.Name).Debug("interface already has a TCX PCA ingress hook ignore")
+			} else {
+				return fmt.Errorf("failed to attach PCA TCX ingress: %w", err)
+			}
 		}
 		p.ingressTCXLink[iface] = ingLink
 		ilog.WithField("interface", iface.Name).Debug("successfully attach PCA ingressTCX hook")


### PR DESCRIPTION
## Description

when update FC the TCS handle is still attached to interface 
## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
