### PR TITLE
NETOBSERV-1703 Add enrichment in packet capture

### DIFF
--- a/examples/packetcapture-dump/client/packetcapture-client.go
+++ b/examples/packetcapture-dump/client/packetcapture-client.go
@@ -23,9 +23,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/netobserv/netobserv-ebpf-agent/pkg/exporter"
 	grpc "github.com/netobserv/netobserv-ebpf-agent/pkg/grpc/packet"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/pbpacket"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/utils"
 
 	"github.com/google/gopacket/layers"
 )
@@ -67,7 +67,7 @@ func main() {
 			os.Exit(1)
 		}
 		// write pcap file header
-		_, err = f.Write(exporter.GetPCAPFileHeader(snapshotlen, layers.LinkTypeEthernet))
+		_, err = f.Write(utils.GetPCAPFileHeader(snapshotlen, layers.LinkTypeEthernet))
 		if err != nil {
 			fmt.Println("Write file header failed:", err.Error())
 			os.Exit(1)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -305,7 +305,7 @@ func buildFlowExporter(cfg *Config, m *metrics.Metrics) (node.TerminalFunc[[]*fl
 	case "ipfix+tcp":
 		return buildIPFIXExporter(cfg, "tcp")
 	case "direct-flp":
-		return buildDirectFLPExporter(cfg)
+		return buildFlowDirectFLPExporter(cfg)
 	default:
 		return nil, fmt.Errorf("wrong flow export type %s", cfg.Export)
 	}
@@ -323,7 +323,7 @@ func buildGRPCExporter(cfg *Config, m *metrics.Metrics) (node.TerminalFunc[[]*fl
 	return grpcExporter.ExportFlows, nil
 }
 
-func buildDirectFLPExporter(cfg *Config) (node.TerminalFunc[[]*flow.Record], error) {
+func buildFlowDirectFLPExporter(cfg *Config) (node.TerminalFunc[[]*flow.Record], error) {
 	flpExporter, err := exporter.StartDirectFLP(cfg.FLPConfig, cfg.BuffersLength)
 	if err != nil {
 		return nil, err

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -40,7 +40,7 @@ type Config struct {
 	AgentIPType string `env:"AGENT_IP_TYPE" envDefault:"any"`
 	// Export selects the exporter protocol.
 	// Accepted values for Flows are: grpc (default), kafka, ipfix+udp, ipfix+tcp or direct-flp.
-	// Accepted values for Packets are: grpc (default) or tcp
+	// Accepted values for Packets are: grpc (default) or direct-flp
 	Export string `env:"EXPORT" envDefault:"grpc"`
 	// Host is the host name or IP of the flow or packet collector, when the EXPORT variable is
 	// set to "grpc"

--- a/pkg/agent/packets_agent.go
+++ b/pkg/agent/packets_agent.go
@@ -175,9 +175,19 @@ func buildPacketExporter(cfg *Config) (node.TerminalFunc[[]*flow.PacketRecord], 
 	switch cfg.Export {
 	case "grpc":
 		return buildGRPCPacketExporter(cfg)
+	case "direct-flp":
+		return buildPacketDirectFLPExporter(cfg)
 	default:
 		return nil, fmt.Errorf("unsupported packet export type %s", cfg.Export)
 	}
+}
+
+func buildPacketDirectFLPExporter(cfg *Config) (node.TerminalFunc[[]*flow.PacketRecord], error) {
+	flpExporter, err := exporter.StartDirectFLP(cfg.FLPConfig, cfg.BuffersLength)
+	if err != nil {
+		return nil, err
+	}
+	return flpExporter.ExportPackets, nil
 }
 
 // Run a Packets agent. The function will keep running in the same thread

--- a/pkg/decode/decode_protobuf.go
+++ b/pkg/decode/decode_protobuf.go
@@ -164,6 +164,10 @@ func PacketToMap(pr *flow.PacketRecord) config.GenericMap {
 		udp, _ := udpLayer.(*layers.UDP)
 		out["SrcPort"] = udp.SrcPort.String()
 		out["DstPort"] = udp.DstPort.String()
+	} else if sctpLayer := packet.Layer(layers.LayerTypeSCTP); sctpLayer != nil {
+		sctp, _ := sctpLayer.(*layers.SCTP)
+		out["SrcPort"] = sctp.SrcPort.String()
+		out["DstPort"] = sctp.DstPort.String()
 	}
 
 	if ipv4Layer := packet.Layer(layers.LayerTypeIPv4); ipv4Layer != nil {

--- a/pkg/exporter/direct_flp.go
+++ b/pkg/exporter/direct_flp.go
@@ -45,6 +45,18 @@ func (d *DirectFLP) ExportFlows(input <-chan []*flow.Record) {
 	}
 }
 
+// ExportPackets accepts slices of *flow.PacketRecord by its input channel, converts them
+// to *pbflow.Records instances, and submits them to the collector.
+func (d *DirectFLP) ExportPackets(input <-chan []*flow.PacketRecord) {
+	for inputPackets := range input {
+		for _, packet := range inputPackets {
+			if len(packet.Stream) != 0 {
+				d.fwd <- decode.PacketToMap(packet)
+			}
+		}
+	}
+}
+
 func (d *DirectFLP) Close() {
 	close(d.fwd)
 }


### PR DESCRIPTION
## Description

This PR allows pcap parsing to generic map. Check [CLI implementation](https://github.com/netobserv/network-observability-cli/pull/61) for usage.

## Dependencies

https://github.com/netobserv/network-observability-cli/pull/61

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
