### PR TITLE
NETOBSERV-1739 move kernel version check to its own pkg

### DIFF
--- a/pkg/ebpf/tracer.go
+++ b/pkg/ebpf/tracer.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/ifaces"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/kernel"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/metrics"
-	"github.com/netobserv/netobserv-ebpf-agent/pkg/utils"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/btf"
@@ -133,7 +133,7 @@ func NewFlowFetcher(cfg *FlowFetcherConfig) (*FlowFetcher, error) {
 		return nil, fmt.Errorf("rewriting BPF constants definition: %w", err)
 	}
 
-	oldKernel := utils.IsKernelOlderThan("5.14.0")
+	oldKernel := kernel.IsKernelOlderThan("5.14.0")
 	if oldKernel {
 		log.Infof("kernel older than 5.14.0 detected: not all hooks are supported")
 	}

--- a/pkg/kernel/kernel_utils.go
+++ b/pkg/kernel/kernel_utils.go
@@ -1,0 +1,80 @@
+package kernel
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	versionRegex  = regexp.MustCompile(`^(\d+)\.(\d+).(\d+).*$`)
+	kernelVersion uint32
+	log           = logrus.WithField("component", "kernel")
+)
+
+func init() {
+	var err error
+	kernelVersion, err = currentKernelVersion()
+	if err != nil {
+		log.Errorf("failed to get current kernel version: %v", err)
+	}
+}
+
+func IsKernelOlderThan(version string) bool {
+	refVersion, err := kernelVersionFromReleaseString(version)
+	if err != nil {
+		log.Warnf("failed to get kernel version from release string: %v", err)
+		return false
+	}
+	return kernelVersion != 0 && kernelVersion < refVersion
+}
+
+// kernelVersionFromReleaseString converts a release string with format
+// 4.4.2[-1] to a kernel version number in LINUX_VERSION_CODE format.
+// That is, for kernel "a.b.c", the version number will be (a<<16 + b<<8 + c)
+func kernelVersionFromReleaseString(releaseString string) (uint32, error) {
+	versionParts := versionRegex.FindStringSubmatch(releaseString)
+	if len(versionParts) != 4 {
+		return 0, fmt.Errorf("got invalid release version %q (expected format '4.3.2-1')", releaseString)
+	}
+	major, err := strconv.Atoi(versionParts[1])
+	if err != nil {
+		return 0, err
+	}
+
+	minor, err := strconv.Atoi(versionParts[2])
+	if err != nil {
+		return 0, err
+	}
+
+	patch, err := strconv.Atoi(versionParts[3])
+	if err != nil {
+		return 0, err
+	}
+	out := major*256*256 + minor*256 + patch
+	return uint32(out), nil
+}
+
+func currentKernelVersion() (uint32, error) {
+	var buf syscall.Utsname
+	if err := syscall.Uname(&buf); err != nil {
+		return 0, err
+	}
+	releaseString := strings.Trim(utsnameStr(buf.Release[:]), "\x00")
+	return kernelVersionFromReleaseString(releaseString)
+}
+
+func utsnameStr[T int8 | uint8](in []T) string {
+	out := make([]byte, len(in))
+	for i := 0; i < len(in); i++ {
+		if in[i] == 0 {
+			break
+		}
+		out = append(out, byte(in[i]))
+	}
+	return string(out)
+}

--- a/pkg/kernel/kernel_utils_test.go
+++ b/pkg/kernel/kernel_utils_test.go
@@ -1,4 +1,4 @@
-package utils
+package kernel
 
 import (
 	"testing"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,26 +3,7 @@ package utils
 import (
 	"fmt"
 	"net"
-	"regexp"
-	"strconv"
-	"strings"
-	"syscall"
-
-	"github.com/sirupsen/logrus"
 )
-
-var (
-	kernelVersion uint32
-	log           = logrus.WithField("component", "utils")
-)
-
-func init() {
-	var err error
-	kernelVersion, err = currentKernelVersion()
-	if err != nil {
-		log.Errorf("failed to get current kernel version: %v", err)
-	}
-}
 
 // GetSocket returns socket string in the correct format based on address family
 func GetSocket(hostIP string, hostPort int) string {
@@ -32,61 +13,4 @@ func GetSocket(hostIP string, hostPort int) string {
 		socket = fmt.Sprintf("[%s]:%d", hostIP, hostPort)
 	}
 	return socket
-}
-
-func IsKernelOlderThan(version string) bool {
-	refVersion, err := kernelVersionFromReleaseString(version)
-	if err != nil {
-		log.Warnf("failed to get kernel version from release string: %v", err)
-		return false
-	}
-	return kernelVersion != 0 && kernelVersion < refVersion
-}
-
-var versionRegex = regexp.MustCompile(`^(\d+)\.(\d+).(\d+).*$`)
-
-// kernelVersionFromReleaseString converts a release string with format
-// 4.4.2[-1] to a kernel version number in LINUX_VERSION_CODE format.
-// That is, for kernel "a.b.c", the version number will be (a<<16 + b<<8 + c)
-func kernelVersionFromReleaseString(releaseString string) (uint32, error) {
-	versionParts := versionRegex.FindStringSubmatch(releaseString)
-	if len(versionParts) != 4 {
-		return 0, fmt.Errorf("got invalid release version %q (expected format '4.3.2-1')", releaseString)
-	}
-	major, err := strconv.Atoi(versionParts[1])
-	if err != nil {
-		return 0, err
-	}
-
-	minor, err := strconv.Atoi(versionParts[2])
-	if err != nil {
-		return 0, err
-	}
-
-	patch, err := strconv.Atoi(versionParts[3])
-	if err != nil {
-		return 0, err
-	}
-	out := major*256*256 + minor*256 + patch
-	return uint32(out), nil
-}
-
-func currentKernelVersion() (uint32, error) {
-	var buf syscall.Utsname
-	if err := syscall.Uname(&buf); err != nil {
-		return 0, err
-	}
-	releaseString := strings.Trim(utsnameStr(buf.Release[:]), "\x00")
-	return kernelVersionFromReleaseString(releaseString)
-}
-
-func utsnameStr[T int8 | uint8](in []T) string {
-	out := make([]byte, len(in))
-	for i := 0; i < len(in); i++ {
-		if in[i] == 0 {
-			break
-		}
-		out = append(out, byte(in[i]))
-	}
-	return string(out)
 }


### PR DESCRIPTION
## Description

move kernel version check to its own pkg
## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
