### PR TITLE
NETOBSERV-1805: make sure to cleanup pod veth's hooks when pods is deleted

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -75,7 +75,7 @@ func configureInformer(cfg *Config, log *logrus.Entry) ifaces.Informer {
 
 }
 
-func interfaceListener(ctx context.Context, ifaceEvents <-chan ifaces.Event, slog *logrus.Entry, eventAdded func(iface ifaces.Interface)) {
+func interfaceListener(ctx context.Context, ifaceEvents <-chan ifaces.Event, slog *logrus.Entry, processEvent func(iface ifaces.Interface, add bool)) {
 	for {
 		select {
 		case <-ctx.Done():
@@ -85,10 +85,9 @@ func interfaceListener(ctx context.Context, ifaceEvents <-chan ifaces.Event, slo
 			slog.WithField("event", event).Debug("received event")
 			switch event.Type {
 			case ifaces.EventAdded:
-				eventAdded(event.Interface)
+				processEvent(event.Interface, true)
 			case ifaces.EventDeleted:
-				// qdiscs, ingress and egress filters are automatically deleted so we don't need to
-				// specifically detach them from the ebpfFetcher
+				processEvent(event.Interface, false)
 			default:
 				slog.WithField("event", event).Warn("unknown event type")
 			}
@@ -125,7 +124,9 @@ type Flows struct {
 type ebpfFlowFetcher interface {
 	io.Closer
 	Register(iface ifaces.Interface) error
+	UnRegister(iface ifaces.Interface) error
 	AttachTCX(iface ifaces.Interface) error
+	DetachTCX(iface ifaces.Interface) error
 
 	LookupAndDeleteMap(*metrics.Metrics) map[ebpf.BpfFlowId][]ebpf.BpfFlowMetrics
 	DeleteMapsStaleEntries(timeOut time.Duration)
@@ -434,7 +435,7 @@ func (f *Flows) Status() Status {
 
 // interfacesManager uses an informer to check new/deleted network interfaces. For each running
 // interface, it registers a flow ebpfFetcher that will forward new flows to the returned channel
-// TODO: consider move this method and "onInterfaceAdded" to another type
+// TODO: consider move this method and "onInterfaceEvent" to another type
 func (f *Flows) interfacesManager(ctx context.Context) error {
 	slog := alog.WithField("function", "interfacesManager")
 
@@ -444,7 +445,7 @@ func (f *Flows) interfacesManager(ctx context.Context) error {
 		return fmt.Errorf("instantiating interfaces' informer: %w", err)
 	}
 
-	go interfaceListener(ctx, ifaceEvents, slog, f.onInterfaceAdded)
+	go interfaceListener(ctx, ifaceEvents, slog, f.onInterfaceEvent)
 
 	return nil
 }
@@ -500,7 +501,7 @@ func (f *Flows) buildAndStartPipeline(ctx context.Context) (*node.Terminal[[]*fl
 	return export, nil
 }
 
-func (f *Flows) onInterfaceAdded(iface ifaces.Interface) {
+func (f *Flows) onInterfaceEvent(iface ifaces.Interface, add bool) {
 	// ignore interfaces that do not match the user configuration acceptance/exclusion lists
 	allowed, err := f.filter.Allowed(iface.Name)
 	if err != nil {
@@ -512,14 +513,28 @@ func (f *Flows) onInterfaceAdded(iface ifaces.Interface) {
 			Debug("interface does not match the allow/exclusion filters. Ignoring")
 		return
 	}
-	alog.WithField("interface", iface).Info("interface detected. trying to attach TCX hook")
-	if err := f.ebpf.AttachTCX(iface); err != nil {
-		alog.WithField("interface", iface).WithError(err).
-			Info("can't attach to TCx hook flow ebpfFetcher. fall back to use legacy TC hook")
-		if err := f.ebpf.Register(iface); err != nil {
+	if add {
+		alog.WithField("interface", iface).Info("interface detected. trying to attach TCX hook")
+		if err := f.ebpf.AttachTCX(iface); err != nil {
 			alog.WithField("interface", iface).WithError(err).
-				Warn("can't register flow ebpfFetcher. Ignoring")
-			return
+				Info("can't attach to TCx hook flow ebpfFetcher. fall back to use legacy TC hook")
+			if err := f.ebpf.Register(iface); err != nil {
+				alog.WithField("interface", iface).WithError(err).
+					Warn("can't register flow ebpfFetcher. Ignoring")
+				return
+			}
 		}
+	} else {
+		alog.WithField("interface", iface).Info("interface deleted. trying to detach TCX hook")
+		if err := f.ebpf.DetachTCX(iface); err != nil {
+			alog.WithField("interface", iface).WithError(err).
+				Info("can't detach from TCx hook flow ebpfFetcher. fall back to use legacy TC hook")
+			if err := f.ebpf.UnRegister(iface); err != nil {
+				alog.WithField("interface", iface).WithError(err).
+					Warn("can't unregister flow ebpfFetcher. Ignoring")
+				return
+			}
+		}
+
 	}
 }

--- a/pkg/ifaces/watcher.go
+++ b/pkg/ifaces/watcher.go
@@ -82,6 +82,9 @@ func (w *Watcher) sendUpdates(ctx context.Context, ns string, out chan Event) {
 				"netnsHandle": netnsHandle.String(),
 				"error":       err,
 			}).Debug("linkSubscribe failed retry")
+			if err := netnsHandle.Close(); err != nil {
+				log.WithError(err).Warn("netnsHandle close failed")
+			}
 			return false, nil
 		}
 

--- a/pkg/test/tracer_fake.go
+++ b/pkg/test/tracer_fake.go
@@ -36,7 +36,16 @@ func (m *TracerFake) Register(iface ifaces.Interface) error {
 	return nil
 }
 
+func (m *TracerFake) UnRegister(iface ifaces.Interface) error {
+	m.interfaces[iface] = struct{}{}
+	return nil
+}
+
 func (m *TracerFake) AttachTCX(_ ifaces.Interface) error {
+	return nil
+}
+
+func (m *TracerFake) DetachTCX(_ ifaces.Interface) error {
 	return nil
 }
 


### PR DESCRIPTION
## Description

Today ebpf agent only cleanup pods when the pod restarts but in this issue pods where continosly recreated but it was never deleted causing the fd leak

this issue only in v1.6.1 releases because of https://github.com/netobserv/netobserv-ebpf-agent/pull/358 fix partily and introduction of TCX hook

## Dependencies


n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
