### PR TITLE
backport: NETOBSERV-1633 Konflux 

### DIFF
--- a/hack/update-build.sh
+++ b/hack/update-build.sh
@@ -15,6 +15,7 @@ LABEL maintainer="support@redhat.com"
 LABEL io.openshift.tags="network-observability-ebpf-agent"
 LABEL upstream-vcs-ref="${COMMIT}"
 LABEL upstream-vcs-type="git"
+LABEL description="The Network Observability eBPF Agent allows collecting and aggregating all the ingress and egress flows on a Linux host."
 EOF
 
 sed -i 's/\(FROM.*\)docker.io\/library\/golang:1.22\(.*\)/\1brew.registry.redhat.io\/rh-osbs\/openshift-golang-builder:v1.22.5-202407301806.g4c8b32d.el9\2/g' ./Dockerfile


### PR DESCRIPTION
## Description

Backport of Konflux relatated modifications.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
