### PR TITLE
Add enrichment stats

### DIFF
--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -936,7 +936,7 @@ func (m *FlowFetcher) increaseEnrichmentStats(met *metrics.Metrics, flow *model.
 			flow.AdditionalMetrics.DnsRecord.Id != 0,
 			flow.AdditionalMetrics.FlowRtt != 0,
 			flow.AdditionalMetrics.PktDrops.Packets != 0,
-			flow.AdditionalMetrics.NetworkEventsIdx != 0,
+			!model.AllZerosMetaData(flow.AdditionalMetrics.NetworkEvents[0]),
 			!model.AllZeroIP(model.IP(flow.AdditionalMetrics.TranslatedFlow.Daddr)),
 		)
 	} else {

--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -937,7 +937,7 @@ func (m *FlowFetcher) increaseEnrichmentStats(met *metrics.Metrics, flow *model.
 			flow.AdditionalMetrics.FlowRtt != 0,
 			flow.AdditionalMetrics.PktDrops.Packets != 0,
 			flow.AdditionalMetrics.NetworkEventsIdx != 0,
-			flow.AdditionalMetrics.TranslatedFlow.ZoneId != 0,
+			!model.AllZeroIP(model.IP(flow.AdditionalMetrics.TranslatedFlow.Daddr)),
 		)
 	} else {
 		met.FlowEnrichmentCounter.Increase(false, false, false, false, false)

--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -919,6 +919,7 @@ func (m *FlowFetcher) LookupAndDeleteMap(met *metrics.Metrics) map[ebpf.BpfFlowI
 		for iMet := range additionalMetrics {
 			flow.AccumulateAdditional(&additionalMetrics[iMet])
 		}
+		m.increaseEnrichmentStats(met, &flow)
 		flows[id] = flow
 	}
 	met.BufferSizeGauge.WithBufferName("additionalmap").Set(float64(countAdditional))
@@ -927,6 +928,20 @@ func (m *FlowFetcher) LookupAndDeleteMap(met *metrics.Metrics) map[ebpf.BpfFlowI
 
 	m.ReadGlobalCounter(met)
 	return flows
+}
+
+func (m *FlowFetcher) increaseEnrichmentStats(met *metrics.Metrics, flow *model.BpfFlowContent) {
+	if flow.AdditionalMetrics != nil {
+		met.FlowEnrichmentCounter.Increase(
+			flow.AdditionalMetrics.DnsRecord.Id != 0,
+			flow.AdditionalMetrics.FlowRtt != 0,
+			flow.AdditionalMetrics.PktDrops.Packets != 0,
+			flow.AdditionalMetrics.NetworkEventsIdx != 0,
+			flow.AdditionalMetrics.TranslatedFlow.ZoneId != 0,
+		)
+	} else {
+		met.FlowEnrichmentCounter.Increase(false, false, false, false, false)
+	}
 }
 
 // ReadGlobalCounter reads the global counter and updates drop flows counter metrics


### PR DESCRIPTION
New metric: `netobserv_agent_flows_enrichment_total`

The goal is to be able to track regressions in terms of quantity of flows being enriched.

Example of query:
`sum(rate(netobserv_agent_flows_enrichment_total[1m])) by (hasDNS, hasRTT, hasDrops, hasNetEvents)`

![image](https://github.com/user-attachments/assets/315d8a63-b0a6-41e8-8a3d-eaee1c609ad4)

Or, to have the proportion of flows with RTT for instance:
`100 * sum(rate(netobserv_agent_flows_enrichment_total{hasRTT="true"}[1m])) / sum(rate(netobserv_agent_flows_enrichment_total[1m]))`
