### PR TITLE
fix make sure flow filter is on by default for pca

### DIFF
--- a/pkg/agent/packets_agent.go
+++ b/pkg/agent/packets_agent.go
@@ -78,27 +78,25 @@ func PacketsAgent(cfg *Config) (*Packets, error) {
 		debug = true
 	}
 	filterRules := make([]*tracer.FilterConfig, 0)
-	if cfg.EnableFlowFilter {
-		var flowFilters []*FlowFilter
-		if err := json.Unmarshal([]byte(cfg.FlowFilterRules), &flowFilters); err != nil {
-			return nil, err
-		}
+	var flowFilters []*FlowFilter
+	if err := json.Unmarshal([]byte(cfg.FlowFilterRules), &flowFilters); err != nil {
+		return nil, err
+	}
 
-		for _, r := range flowFilters {
-			filterRules = append(filterRules, &tracer.FilterConfig{
-				FilterAction:          r.FilterAction,
-				FilterDirection:       r.FilterDirection,
-				FilterIPCIDR:          r.FilterIPCIDR,
-				FilterProtocol:        r.FilterProtocol,
-				FilterPeerIP:          r.FilterPeerIP,
-				FilterDestinationPort: tracer.ConvertFilterPortsToInstr(r.FilterDestinationPort, r.FilterDestinationPortRange, r.FilterDestinationPorts),
-				FilterSourcePort:      tracer.ConvertFilterPortsToInstr(r.FilterSourcePort, r.FilterSourcePortRange, r.FilterSourcePorts),
-				FilterPort:            tracer.ConvertFilterPortsToInstr(r.FilterPort, r.FilterPortRange, r.FilterPorts),
-				FilterTCPFlags:        r.FilterTCPFlags,
-				FilterDrops:           r.FilterDrops,
-				FilterSample:          r.FilterSample,
-			})
-		}
+	for _, r := range flowFilters {
+		filterRules = append(filterRules, &tracer.FilterConfig{
+			FilterAction:          r.FilterAction,
+			FilterDirection:       r.FilterDirection,
+			FilterIPCIDR:          r.FilterIPCIDR,
+			FilterProtocol:        r.FilterProtocol,
+			FilterPeerIP:          r.FilterPeerIP,
+			FilterDestinationPort: tracer.ConvertFilterPortsToInstr(r.FilterDestinationPort, r.FilterDestinationPortRange, r.FilterDestinationPorts),
+			FilterSourcePort:      tracer.ConvertFilterPortsToInstr(r.FilterSourcePort, r.FilterSourcePortRange, r.FilterSourcePorts),
+			FilterPort:            tracer.ConvertFilterPortsToInstr(r.FilterPort, r.FilterPortRange, r.FilterPorts),
+			FilterTCPFlags:        r.FilterTCPFlags,
+			FilterDrops:           r.FilterDrops,
+			FilterSample:          r.FilterSample,
+		})
 	}
 	ebpfConfig := &tracer.FlowFetcherConfig{
 		EnableIngress:  ingress,


### PR DESCRIPTION
## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
