### PR TITLE
Add missing , after additional metrics name

### DIFF
--- a/hack/build-bytecode-images-multi.sh
+++ b/hack/build-bytecode-images-multi.sh
@@ -21,16 +21,20 @@ PROGRAMS='{
 "nf_nat_manip_pkt":"kprobe"
 }'
 
+echo "$PROGRAMS" | jq empty || { echo "Invalid JSON in PROGRAMS"; exit 1; }
+
 # MAPS is a list of <map name>:<map type> tuples
 MAPS='{
 "direct_flows":"ringbuf",
 "aggregated_flows":"hash",
-"additional_flow_metrics":"per_cpu_hash"
+"additional_flow_metrics":"per_cpu_hash",
 "packets_record":"perf_event_array",
 "dns_flows":"hash",
 "global_counters":"per_cpu_array",
 "filter_map":"lpm_trie"
 }'
+
+echo "$MAPS" | jq empty || { echo "Invalid JSON in MAPS"; exit 1; }
 
 if [[ ${OCI_BIN} == "docker" ]]; then
   docker buildx create --name bytecode-builder --use


### PR DESCRIPTION
## Description

Add missing `,` after additional metrics map
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
