### PR TITLE
Always set the additional map size

### DIFF
--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -132,11 +132,8 @@ func NewFlowFetcher(cfg *FlowFetcherConfig) (*FlowFetcher, error) {
 
 		// Resize maps according to user-provided configuration
 		spec.Maps[aggregatedFlowsMap].MaxEntries = uint32(cfg.CacheMaxSize)
-		if isEBPFFeaturesEnabled(cfg) {
-			spec.Maps[additionalFlowMetrics].MaxEntries = uint32(cfg.CacheMaxSize)
-		} else {
-			spec.Maps[additionalFlowMetrics].MaxEntries = 1
-		}
+		spec.Maps[additionalFlowMetrics].MaxEntries = uint32(cfg.CacheMaxSize)
+
 		// remove pinning from all maps
 		maps2Name := []string{"aggregated_flows", "additional_flow_metrics", "direct_flows", "dns_flows", "filter_map", "global_counters", "packet_record"}
 		for _, m := range maps2Name {
@@ -366,13 +363,6 @@ func NewFlowFetcher(cfg *FlowFetcherConfig) (*FlowFetcher, error) {
 		useEbpfManager:              cfg.UseEbpfManager,
 		pinDir:                      pinDir,
 	}, nil
-}
-
-func isEBPFFeaturesEnabled(cfg *FlowFetcherConfig) bool {
-	if cfg.EnableNetworkEventsMonitoring || cfg.EnableRTT || cfg.EnablePktDrops || cfg.EnableDNSTracker || cfg.EnablePktTranslation {
-		return true
-	}
-	return false
 }
 
 func (m *FlowFetcher) AttachTCX(iface ifaces.Interface) error {


### PR DESCRIPTION
## Description

additional map include interfaces list the packets go through regardless if agent features are
enabled or not

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
