### PR TITLE
fix linter issue in latest code

### DIFF
--- a/pkg/flow/account.go
+++ b/pkg/flow/account.go
@@ -100,7 +100,7 @@ func (c *Accounter) evict(entries map[ebpf.BpfFlowId]*ebpf.BpfFlowMetrics, evict
 	monotonicNow := uint64(c.monoClock())
 	records := make([]*model.Record, 0, len(entries))
 	for key, metrics := range entries {
-		flowContent := model.NewBpfFlowContent(*metrics)
+		flowContent := model.NewBpfFlowContent(metrics)
 		records = append(records, model.NewRecord(key, &flowContent, now, monotonicNow, c.s))
 	}
 	c.metrics.EvictionCounter.WithSourceAndReason("accounter", reason).Inc()

--- a/pkg/model/flow_content.go
+++ b/pkg/model/flow_content.go
@@ -9,8 +9,8 @@ type BpfFlowContent struct {
 	AdditionalMetrics *ebpf.BpfAdditionalMetrics
 }
 
-func NewBpfFlowContent(metrics ebpf.BpfFlowMetrics) BpfFlowContent {
-	return BpfFlowContent{BpfFlowMetrics: &metrics}
+func NewBpfFlowContent(metrics *ebpf.BpfFlowMetrics) BpfFlowContent {
+	return BpfFlowContent{BpfFlowMetrics: metrics}
 }
 
 func (p *BpfFlowContent) AccumulateBase(other *ebpf.BpfFlowMetrics) {

--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -890,7 +890,9 @@ func (m *FlowFetcher) LookupAndDeleteMap(met *metrics.Metrics) map[ebpf.BpfFlowI
 			met.Errors.WithErrorName("flow-fetcher", "CannotDeleteFlows", metrics.HighSeverity).Inc()
 			continue
 		}
-		flows[id] = model.NewBpfFlowContent(baseMetrics)
+		ptrBaseMetrics := &ebpf.BpfFlowMetrics{}
+		*ptrBaseMetrics = baseMetrics
+		flows[id] = model.NewBpfFlowContent(ptrBaseMetrics)
 	}
 
 	// Reiterate on additional metrics

--- a/pkg/tracer/tracer_legacy.go
+++ b/pkg/tracer/tracer_legacy.go
@@ -25,7 +25,9 @@ func (m *FlowFetcher) legacyLookupAndDeleteMap(met *metrics.Metrics) map[ebpf.Bp
 			log.WithError(err).WithField("flowId", id).Warnf("couldn't delete flow entry")
 			met.Errors.WithErrorName("flow-fetcher-legacy", "CannotDeleteFlows", metrics.HighSeverity).Inc()
 		}
-		flows[id] = model.NewBpfFlowContent(baseMetrics)
+		ptrBaseMetrics := &ebpf.BpfFlowMetrics{}
+		*ptrBaseMetrics = baseMetrics
+		flows[id] = model.NewBpfFlowContent(ptrBaseMetrics)
 	}
 	met.BufferSizeGauge.WithBufferName("hashmap-legacy-total").Set(float64(count))
 	met.BufferSizeGauge.WithBufferName("hashmap-legacy-unique").Set(float64(len(flows)))


### PR DESCRIPTION
## Description

```sh
pkg/model/flow_content.go:12:24: hugeParam: metrics is heavy (96 bytes); consider passing it by pointer (gocritic)
```

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
