### PR TITLE
Set short SHA 8 length

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -32,7 +32,7 @@ jobs:
           password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
       - name: get short sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "short_sha=$(git rev-parse --short=8 HEAD)" >> $GITHUB_ENV
       - name: build and push bytecode image
         run: |
           MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.WF_VERSION }} CLEAN_BUILD=1 make bc-images

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -36,7 +36,7 @@ jobs:
           password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
       - name: get short sha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "short_sha=$(git rev-parse --short=8 HEAD)" >> $GITHUB_ENV
       - name: build and push bytecode image
         run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_BC_IMAGE }}:${{ env.short_sha }} CLEAN_BUILD=1 make bc-images
       - name: build and push manifest with images

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ OCI_BUILD_OPTS ?=
 
 ifneq ($(CLEAN_BUILD),)
 	BUILD_DATE := $(shell date +%Y-%m-%d\ %H:%M)
-	BUILD_SHA := $(shell git rev-parse --short HEAD)
+	BUILD_SHA := $(shell git rev-parse --short=8 HEAD)
 	LDFLAGS ?= -X 'main.buildVersion=${VERSION}-${BUILD_SHA}' -X 'main.buildDate=${BUILD_DATE}'
 endif
 


### PR DESCRIPTION
I'd like to normalize how short-sha are generated (will do the same on other repos)
The goal is to have the same size usually used in quay tags and on our local machines such as when doing `git log --abbrev-commit` - although it might also depend on local machines specific configs