### PR TITLE
release-1.8: Fix arg usage for downstream builds

### DIFF
--- a/Dockerfile.downstream
+++ b/Dockerfile.downstream
@@ -5,7 +5,7 @@ ARG COMMIT
 FROM --platform=linux/$TARGETARCH brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23 as builder
 
 ARG TARGETARCH=amd64
-ARG VERSION="unknown"
+ARG BUILDVERSION="1.8.0"
 ARG COMMIT
 
 WORKDIR /opt/app-root
@@ -19,7 +19,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 
 # Build
-RUN GOARCH=$TARGETARCH go build -ldflags "-X 'main.buildVersion=${VERSION}-${COMMIT}' -X 'main.buildDate=`date +%Y-%m-%d\ %H:%M`'" -mod vendor -a -o bin/netobserv-ebpf-agent cmd/netobserv-ebpf-agent.go
+RUN GOARCH=$TARGETARCH go build -ldflags "-X 'main.buildVersion=${BUILDVERSION}' -X 'main.buildDate=`date +%Y-%m-%d\ %H:%M`'" -mod vendor -a -o bin/netobserv-ebpf-agent cmd/netobserv-ebpf-agent.go
 
 # Create final image from minimal + built binary
 FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi-minimal:9.5-1738816775
@@ -38,7 +38,7 @@ LABEL io.k8s.description="Network Observability eBPF Agent"
 LABEL summary="Network Observability eBPF Agent"
 LABEL maintainer="support@redhat.com"
 LABEL io.openshift.tags="network-observability-ebpf-agent"
-LABEL upstream-vcs-ref="$COMMIT"
+LABEL upstream-vcs-ref=$COMMIT
 LABEL upstream-vcs-type="git"
 LABEL description="The Network Observability eBPF Agent allows collecting and aggregating all the ingress and egress flows on a Linux host."
-LABEL version="1.8.0"
+LABEL version=$BUILDVERSION


### PR DESCRIPTION
## Description

Fix arg usage for downstream builds

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
