### PR TITLE
NETOBSERV-2092 Inject drop events in drop fields

### DIFF
--- a/pkg/decode/decode_protobuf.go
+++ b/pkg/decode/decode_protobuf.go
@@ -149,6 +149,14 @@ func RecordToMap(fr *model.Record) config.GenericMap {
 
 	if len(fr.NetworkMonitorEventsMD) != 0 {
 		out["NetworkEvents"] = fr.NetworkMonitorEventsMD
+		for _, event := range fr.NetworkMonitorEventsMD {
+			// override drop fields when network event action is dropped
+			if event["Action"] == "drop" {
+				out["PktDropBytes"] = fr.Metrics.Bytes
+				out["PktDropPackets"] = fr.Metrics.Packets
+				out["PktDropLatestDropCause"] = "OVS_DROP_EXPLICIT"
+			}
+		}
 	}
 
 	return out


### PR DESCRIPTION
## Description

Force OVS_DROP cause when received a drop event.
Also set dropped bytes and packets to have proper metrics.

Original discussion: https://github.com/netobserv/netobserv.github.io/pull/6#discussion_r1939152634

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
