### PR TITLE
bpfman needs to have ns string instead of the nshandle

### DIFF
--- a/pkg/ifaces/informer.go
+++ b/pkg/ifaces/informer.go
@@ -36,9 +36,10 @@ type Event struct {
 }
 
 type Interface struct {
-	Name  string
-	Index int
-	NetNS netns.NsHandle
+	Name   string
+	Index  int
+	NetNS  netns.NsHandle
+	NSName string
 }
 
 // Informer provides notifications about each network interface that is added or removed
@@ -48,7 +49,7 @@ type Informer interface {
 	Subscribe(ctx context.Context) (<-chan Event, error)
 }
 
-func netInterfaces(nsh netns.NsHandle) ([]Interface, error) {
+func netInterfaces(nsh netns.NsHandle, ns string) ([]Interface, error) {
 	handle, err := netlink.NewHandleAt(nsh)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create handle for netns (%s): %w", nsh.String(), err)
@@ -63,7 +64,7 @@ func netInterfaces(nsh netns.NsHandle) ([]Interface, error) {
 
 	names := make([]Interface, len(links))
 	for i, link := range links {
-		names[i] = Interface{Name: link.Attrs().Name, Index: link.Attrs().Index, NetNS: nsh}
+		names[i] = Interface{Name: link.Attrs().Name, Index: link.Attrs().Index, NetNS: nsh, NSName: ns}
 	}
 	return names, nil
 }

--- a/pkg/ifaces/poller.go
+++ b/pkg/ifaces/poller.go
@@ -13,7 +13,7 @@ import (
 type Poller struct {
 	period     time.Duration
 	current    map[Interface]struct{}
-	interfaces func(handle netns.NsHandle) ([]Interface, error)
+	interfaces func(handle netns.NsHandle, ns string) ([]Interface, error)
 	bufLen     int
 }
 
@@ -58,7 +58,7 @@ func (np *Poller) pollForEvents(ctx context.Context, ns string, out chan Event) 
 
 	defer ticker.Stop()
 	for {
-		if ifaces, err := np.interfaces(netnsHandle); err != nil {
+		if ifaces, err := np.interfaces(netnsHandle, ns); err != nil {
 			log.WithError(err).Warn("fetching interface names")
 		} else {
 			log.WithField("names", ifaces).Debug("fetched interface names")

--- a/pkg/ifaces/poller_test.go
+++ b/pkg/ifaces/poller_test.go
@@ -19,12 +19,12 @@ func TestPoller(t *testing.T) {
 	// fake net.Interfaces implementation that returns two different sets of
 	// interfaces on successive invocations
 	firstInvocation := true
-	var fakeInterfaces = func(_ netns.NsHandle) ([]Interface, error) {
+	var fakeInterfaces = func(_ netns.NsHandle, _ string) ([]Interface, error) {
 		if firstInvocation {
 			firstInvocation = false
-			return []Interface{{"foo", 1, netns.None()}, {"bar", 2, netns.None()}}, nil
+			return []Interface{{"foo", 1, netns.None(), ""}, {"bar", 2, netns.None(), ""}}, nil
 		}
-		return []Interface{{"foo", 1, netns.None()}, {"bae", 3, netns.None()}}, nil
+		return []Interface{{"foo", 1, netns.None(), ""}, {"bae", 3, netns.None(), ""}}, nil
 	}
 	poller := NewPoller(5*time.Millisecond, 10)
 	poller.interfaces = fakeInterfaces
@@ -33,17 +33,17 @@ func TestPoller(t *testing.T) {
 	require.NoError(t, err)
 	// first poll: two interfaces are added
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"foo", 1, netns.None()}},
+		Event{Type: EventAdded, Interface: Interface{"foo", 1, netns.None(), ""}},
 		getEvent(t, updates, timeout))
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"bar", 2, netns.None()}},
+		Event{Type: EventAdded, Interface: Interface{"bar", 2, netns.None(), ""}},
 		getEvent(t, updates, timeout))
 	// second poll: one interface is added and another is removed
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"bae", 3, netns.None()}},
+		Event{Type: EventAdded, Interface: Interface{"bae", 3, netns.None(), ""}},
 		getEvent(t, updates, timeout))
 	assert.Equal(t,
-		Event{Type: EventDeleted, Interface: Interface{"bar", 2, netns.None()}},
+		Event{Type: EventDeleted, Interface: Interface{"bar", 2, netns.None(), ""}},
 		getEvent(t, updates, timeout))
 	// successive polls: no more events are forwarded
 	select {

--- a/pkg/ifaces/registerer_test.go
+++ b/pkg/ifaces/registerer_test.go
@@ -17,8 +17,8 @@ func TestRegisterer(t *testing.T) {
 	watcher := NewWatcher(10)
 	registry := NewRegisterer(watcher, 10)
 	// mock net.Interfaces and linkSubscriber to control which interfaces are discovered
-	watcher.interfaces = func(_ netns.NsHandle) ([]Interface, error) {
-		return []Interface{{"foo", 1, netns.None()}, {"bar", 2, netns.None()}, {"baz", 3, netns.None()}}, nil
+	watcher.interfaces = func(_ netns.NsHandle, _ string) ([]Interface, error) {
+		return []Interface{{"foo", 1, netns.None(), ""}, {"bar", 2, netns.None(), ""}, {"baz", 3, netns.None(), ""}}, nil
 	}
 	inputLinks := make(chan netlink.LinkUpdate, 10)
 	watcher.linkSubscriberAt = func(_ netns.NsHandle, ch chan<- netlink.LinkUpdate, _ <-chan struct{}) error {

--- a/pkg/ifaces/watcher_test.go
+++ b/pkg/ifaces/watcher_test.go
@@ -19,8 +19,8 @@ func TestWatcher(t *testing.T) {
 
 	watcher := NewWatcher(10)
 	// mock net.Interfaces and linkSubscriber to control which interfaces are discovered
-	watcher.interfaces = func(_ netns.NsHandle) ([]Interface, error) {
-		return []Interface{{"foo", 1, netns.None()}, {"bar", 2, netns.None()}, {"baz", 3, netns.None()}}, nil
+	watcher.interfaces = func(_ netns.NsHandle, _ string) ([]Interface, error) {
+		return []Interface{{"foo", 1, netns.None(), ""}, {"bar", 2, netns.None(), ""}, {"baz", 3, netns.None(), ""}}, nil
 	}
 	inputLinks := make(chan netlink.LinkUpdate, 10)
 	watcher.linkSubscriberAt = func(_ netns.NsHandle, ch chan<- netlink.LinkUpdate, _ <-chan struct{}) error {
@@ -37,23 +37,23 @@ func TestWatcher(t *testing.T) {
 
 	// initial set of fetched elements
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"foo", 1, netns.None()}},
+		Event{Type: EventAdded, Interface: Interface{"foo", 1, netns.None(), ""}},
 		getEvent(t, outputEvents, timeout))
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"bar", 2, netns.None()}},
+		Event{Type: EventAdded, Interface: Interface{"bar", 2, netns.None(), ""}},
 		getEvent(t, outputEvents, timeout))
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"baz", 3, netns.None()}},
+		Event{Type: EventAdded, Interface: Interface{"baz", 3, netns.None(), ""}},
 		getEvent(t, outputEvents, timeout))
 
 	// updates
 	inputLinks <- upAndRunning("bae", 4, netns.None())
 	inputLinks <- down("bar", 2, netns.None())
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"bae", 4, netns.None()}},
+		Event{Type: EventAdded, Interface: Interface{"bae", 4, netns.None(), ""}},
 		getEvent(t, outputEvents, timeout))
 	assert.Equal(t,
-		Event{Type: EventDeleted, Interface: Interface{"bar", 2, netns.None()}},
+		Event{Type: EventDeleted, Interface: Interface{"bar", 2, netns.None(), ""}},
 		getEvent(t, outputEvents, timeout))
 
 	// repeated updates that do not involve a change in the current track of interfaces


### PR DESCRIPTION
## Description

bpfman needs access to netns string not the nshandle
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
