### PR TITLE
NETOBSERV-2215: Add missing IPSec per flow hasIPSec metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -273,13 +273,14 @@ type FlowEnrichmentCounter struct {
 	vec *prometheus.CounterVec
 }
 
-func (c *FlowEnrichmentCounter) Increase(hasDNS, hasRTT, hasDrops, hasNetEvents, hasXlat bool) {
+func (c *FlowEnrichmentCounter) Increase(hasDNS, hasRTT, hasDrops, hasNetEvents, hasXlat, hasIPSec bool) {
 	c.vec.WithLabelValues(
 		strconv.FormatBool(hasDNS),
 		strconv.FormatBool(hasRTT),
 		strconv.FormatBool(hasDrops),
 		strconv.FormatBool(hasNetEvents),
 		strconv.FormatBool(hasXlat),
+		strconv.FormatBool(hasIPSec),
 	).Inc()
 }
 

--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -1031,9 +1031,10 @@ func (m *FlowFetcher) increaseEnrichmentStats(met *metrics.Metrics, flow *model.
 			flow.AdditionalMetrics.PktDrops.Packets != 0,
 			!model.AllZerosMetaData(flow.AdditionalMetrics.NetworkEvents[0]),
 			!model.AllZeroIP(model.IP(flow.AdditionalMetrics.TranslatedFlow.Daddr)),
+			flow.AdditionalMetrics.FlowEncryptedRet == 0 && flow.AdditionalMetrics.FlowEncrypted,
 		)
 	} else {
-		met.FlowEnrichmentCounter.Increase(false, false, false, false, false)
+		met.FlowEnrichmentCounter.Increase(false, false, false, false, false, false)
 	}
 }
 


### PR DESCRIPTION
## Description

Add perflow ipsec metrics
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
