### PR TITLE
Disable cgo on upstream builds and attach binaries to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,3 +43,30 @@ jobs:
           registry: quay.io
       - name: build and push manifest with images
         run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} CLEAN_BUILD=1 make images
+      - name: extract binaries
+        run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} make extract-binaries
+      - name: create draft release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.tag }}
+          release_name: ${{ env.tag }}
+          draft: true
+          prerelease: false
+      - name: upload binaries
+        uses: actions/github-script@v2
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const fs = require('fs').promises;
+            const upload_url = '${{ steps.create_release.outputs.upload_url }}';
+            for (let file of await fs.readdir('./release-assets')) {
+              console.log('uploading', file);
+              await github.repos.uploadReleaseAsset({
+                url: upload_url,
+                name: file,
+                data: await fs.readFile(`./release-assets/${file}`)
+              }); 
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ e2e-logs
 ebpf-agent.tar
 *.pcap
 protoc/
+release-assets/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 
 # Build
-RUN GOARCH=$TARGETARCH go build -ldflags "$LDFLAGS" -mod vendor -a -o bin/netobserv-ebpf-agent cmd/netobserv-ebpf-agent.go
+RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -ldflags "$LDFLAGS" -mod vendor -a -o bin/netobserv-ebpf-agent cmd/netobserv-ebpf-agent.go
 
 # Create final image from minimal + built binary
 FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi-minimal:9.5-1742914212

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,14 @@ define manifest_add_target
 	DOCKER_BUILDKIT=1 $(OCI_BIN) manifest add ${IMAGE} ${IMAGE}-$(1);
 endef
 
+# extract a single arch target binary
+define extract_target
+	echo 'extracting binary from ${IMAGE}-$(1)'; \
+	$(OCI_BIN) create --name agent ${IMAGE}-$(1); \
+	$(OCI_BIN) cp agent:/netobserv-ebpf-agent ./release-assets/netobserv-ebpf-agent-${VERSION}-linux-$(1); \
+	$(OCI_BIN) rm -f agent;
+endef
+
 ##@ General
 
 # The help target prints out all targets with their descriptions organized
@@ -217,6 +225,12 @@ ifeq (${OCI_BIN}, docker)
 else
 	DOCKER_BUILDKIT=1 $(OCI_BIN) manifest push ${IMAGE} docker://${IMAGE};
 endif
+
+.PHONY: extract-binaries
+extract-binaries: ## Extract all MULTIARCH_TARGETS binaries
+	trap 'exit' INT; \
+	mkdir -p release-assets; \
+	$(foreach target,$(MULTIARCH_TARGETS),$(call extract_target,$(target)))
 
 include .mk/bc.mk
 include .mk/shortcuts.mk


### PR DESCRIPTION
See also (same changes): https://github.com/netobserv/flowlogs-pipeline/pull/932
