### PR TITLE
Fix pca - need to unpin ipsec maps

### DIFF
--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -1501,6 +1501,10 @@ func NewPacketFetcher(cfg *FlowFetcherConfig) (*PacketFetcher, error) {
 			TcpRcvKprobe:            nil,
 			KfreeSkb:                nil,
 			NetworkEventsMonitoring: nil,
+			XfrmInputKretprobe:      nil,
+			XfrmOutputKretprobe:     nil,
+			XfrmInputKprobe:         nil,
+			XfrmOutputKprobe:        nil,
 		},
 		BpfMaps: ebpf.BpfMaps{
 			PacketRecord:  newObjects.PacketRecord,

--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -1439,7 +1439,10 @@ func NewPacketFetcher(cfg *FlowFetcherConfig) (*PacketFetcher, error) {
 		filterMap,
 		peerFilterMap,
 		globalCountersMap,
-		pcaRecordsMap} {
+		pcaRecordsMap,
+		ipsecInputMap,
+		ipsecOutputMap,
+	} {
 		spec.Maps[m].Pinning = 0
 	}
 
@@ -1460,6 +1463,8 @@ func NewPacketFetcher(cfg *FlowFetcherConfig) (*PacketFetcher, error) {
 	delete(spec.Programs, tcpFentryHook)
 	delete(spec.Programs, aggregatedFlowsMap)
 	delete(spec.Programs, additionalFlowMetrics)
+	delete(spec.Programs, ipsecInputMap)
+	delete(spec.Programs, ipsecOutputMap)
 	delete(spec.Programs, constSampling)
 	delete(spec.Programs, constHasFilterSampling)
 	delete(spec.Programs, constTraceMessages)


### PR DESCRIPTION
Otherwise we're getting this error while running pca:
```
time="2025-05-12T11:03:12Z" level=fatal msg="[PCA] can't instantiate NetObserv eBPF Agent" error="loading and assigning BPF objects: field IpsecEgressMap: map ipsec_egress_map: pin by name: missing MapOptions.PinPath"
```