### PR TITLE
Add troubleshooting info on interface events

### DIFF
--- a/cmd/netobserv-ebpf-agent.go
+++ b/cmd/netobserv-ebpf-agent.go
@@ -53,7 +53,9 @@ func main() {
 		}()
 	}
 
-	logrus.WithField("configuration", fmt.Sprintf("%#v", config)).Debugf("configuration loaded")
+	cfglog := logrus.New()
+	cfglog.Formatter = &logrus.TextFormatter{DisableQuote: true}
+	cfglog.WithField("configuration", fmt.Sprintf("%#v", config)).Infof("configuration loaded")
 
 	if config.EnablePCA {
 		packetsAgent, err := agent.PacketsAgent(&config)

--- a/pkg/agent/packets_agent.go
+++ b/pkg/agent/packets_agent.go
@@ -43,10 +43,10 @@ type Packets struct {
 
 type ebpfPacketFetcher interface {
 	io.Closer
-	Register(iface ifaces.Interface) error
-	UnRegister(iface ifaces.Interface) error
-	AttachTCX(iface ifaces.Interface) error
-	DetachTCX(iface ifaces.Interface) error
+	Register(iface *ifaces.Interface) error
+	UnRegister(iface *ifaces.Interface) error
+	AttachTCX(iface *ifaces.Interface) error
+	DetachTCX(iface *ifaces.Interface) error
 	LookupAndDeleteMap(*metrics.Metrics) map[int][]*byte
 	ReadPerf() (perf.Record, error)
 }
@@ -132,7 +132,7 @@ func packetsAgent(
 	if err != nil {
 		return nil, err
 	}
-	registerer, err := ifaces.NewRegisterer(informer, cfg)
+	registerer, err := ifaces.NewRegisterer(informer, cfg, metrics.NoOp())
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func (p *Packets) buildAndStartPipeline(ctx context.Context) (*node.Terminal[[]*
 	return export, nil
 }
 
-func (p *Packets) onInterfaceAdded(iface ifaces.Interface, add bool) {
+func (p *Packets) onInterfaceAdded(iface *ifaces.Interface, add bool) {
 	// ignore interfaces that do not match the user configuration acceptance/exclusion lists
 	allowed, err := p.filter.Allowed(iface.Name)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -210,6 +210,8 @@ type Agent struct {
 	EnablePCA bool `env:"ENABLE_PCA" envDefault:"false"`
 	// MetricsEnable enables http server to collect ebpf agent metrics, default is false.
 	MetricsEnable bool `env:"METRICS_ENABLE" envDefault:"false"`
+	// Metrics verbosity level. From more to less verbose: debug, info (default).
+	MetricsLevel string `env:"METRICS_LEVEL" envDefault:"info"`
 	// MetricsServerAddress is the address of the server that collects ebpf agent metrics.
 	MetricsServerAddress string `env:"METRICS_SERVER_ADDRESS"`
 	// MetricsPort is the port of the server that collects ebpf agent metrics.

--- a/pkg/ifaces/informer.go
+++ b/pkg/ifaces/informer.go
@@ -17,6 +17,14 @@ const (
 	EventDeleted
 )
 
+// HookType used for attachment: TC, TCX
+type HookType int
+
+const (
+	TCHook HookType = iota
+	TCXHook
+)
+
 func (e EventType) String() string {
 	switch e {
 	case EventAdded:
@@ -33,15 +41,16 @@ var ilog = logrus.WithField("component", "ifaces.Informer")
 // Event of a network interface, given the type (added, removed) and the interface name
 type Event struct {
 	Type      EventType
-	Interface Interface
+	Interface *Interface
 }
 
 type Interface struct {
-	Name   string
-	Index  int
-	MAC    [6]uint8
-	NetNS  netns.NsHandle
-	NSName string
+	Name     string
+	Index    int
+	MAC      [6]uint8
+	NetNS    netns.NsHandle
+	NSName   string
+	HookType HookType // warning: this might break using this struct in maps, to be verified
 }
 
 // Informer provides notifications about each network interface that is added or removed

--- a/pkg/ifaces/poller.go
+++ b/pkg/ifaces/poller.go
@@ -87,7 +87,7 @@ func (np *Poller) diffNames(events chan Event, ifaces []Interface) {
 			np.current[iface] = struct{}{}
 			events <- Event{
 				Type:      EventAdded,
-				Interface: iface,
+				Interface: &iface,
 			}
 		}
 	}
@@ -98,7 +98,7 @@ func (np *Poller) diffNames(events chan Event, ifaces []Interface) {
 			ilog.WithField("interface", iface).Debug("deleted network interface")
 			events <- Event{
 				Type:      EventDeleted,
-				Interface: iface,
+				Interface: &iface,
 			}
 		}
 	}

--- a/pkg/ifaces/poller_test.go
+++ b/pkg/ifaces/poller_test.go
@@ -32,9 +32,9 @@ func TestPoller(t *testing.T) {
 	var fakeInterfaces = func(_ netns.NsHandle, _ string) ([]Interface, error) {
 		if firstInvocation {
 			firstInvocation = false
-			return []Interface{{"foo", 1, macFoo, netns.None(), ""}, {"bar", 2, macBar, netns.None(), ""}, {"bae", 4, macBae, netns.None(), ""}}, nil
+			return []Interface{{"foo", 1, macFoo, netns.None(), "", TCHook}, {"bar", 2, macBar, netns.None(), "", TCHook}, {"bae", 4, macBae, netns.None(), "", TCHook}}, nil
 		}
-		return []Interface{{"foo", 1, macFoo, netns.None(), ""}, {"baz", 3, macBaz, netns.None(), ""}, {"ovlp", 4, macOverlapped, netns.None(), ""}}, nil
+		return []Interface{{"foo", 1, macFoo, netns.None(), "", TCHook}, {"baz", 3, macBaz, netns.None(), "", TCHook}, {"ovlp", 4, macOverlapped, netns.None(), "", TCHook}}, nil
 	}
 	poller := NewPoller(5*time.Millisecond, 10)
 	poller.interfaces = fakeInterfaces
@@ -43,20 +43,20 @@ func TestPoller(t *testing.T) {
 	require.NoError(t, err)
 	// first poll: two interfaces are added
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"foo", 1, macFoo, netns.None(), ""}},
+		Event{Type: EventAdded, Interface: &Interface{"foo", 1, macFoo, netns.None(), "", TCHook}},
 		getEvent(t, updates, timeout))
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"bar", 2, macBar, netns.None(), ""}},
+		Event{Type: EventAdded, Interface: &Interface{"bar", 2, macBar, netns.None(), "", TCHook}},
 		getEvent(t, updates, timeout))
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"bae", 4, macBae, netns.None(), ""}},
+		Event{Type: EventAdded, Interface: &Interface{"bae", 4, macBae, netns.None(), "", TCHook}},
 		getEvent(t, updates, timeout))
 	// second poll: one interface is added and another is removed
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"baz", 3, macBaz, netns.None(), ""}},
+		Event{Type: EventAdded, Interface: &Interface{"baz", 3, macBaz, netns.None(), "", TCHook}},
 		getEvent(t, updates, timeout))
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"ovlp", 4, macOverlapped, netns.None(), ""}},
+		Event{Type: EventAdded, Interface: &Interface{"ovlp", 4, macOverlapped, netns.None(), "", TCHook}},
 		getEvent(t, updates, timeout))
 	// Order isn't guaranteed for next events, so use assert.ElementsMatch
 	next1 := getEvent(t, updates, timeout)
@@ -64,8 +64,8 @@ func TestPoller(t *testing.T) {
 	assert.ElementsMatch(t,
 		[]Event{next1, next2},
 		[]Event{
-			{Type: EventDeleted, Interface: Interface{"bar", 2, macBar, netns.None(), ""}},
-			{Type: EventDeleted, Interface: Interface{"bae", 4, macBae, netns.None(), ""}},
+			{Type: EventDeleted, Interface: &Interface{"bar", 2, macBar, netns.None(), "", TCHook}},
+			{Type: EventDeleted, Interface: &Interface{"bae", 4, macBae, netns.None(), "", TCHook}},
 		},
 	)
 

--- a/pkg/ifaces/watcher.go
+++ b/pkg/ifaces/watcher.go
@@ -123,7 +123,7 @@ func (w *Watcher) sendUpdates(ctx context.Context, ns string, out chan Event) {
 				w.mutex.Lock()
 				w.current[iface] = struct{}{}
 				w.mutex.Unlock()
-				out <- Event{Type: EventAdded, Interface: iface}
+				out <- Event{Type: EventAdded, Interface: &iface}
 			}
 		}
 	}
@@ -150,7 +150,7 @@ func (w *Watcher) sendUpdates(ctx context.Context, ns string, out chan Event) {
 			}).Debug("Interface up and running")
 			if _, ok := w.current[iface]; !ok {
 				w.current[iface] = struct{}{}
-				out <- Event{Type: EventAdded, Interface: iface}
+				out <- Event{Type: EventAdded, Interface: &iface}
 			}
 		} else {
 			log.WithFields(logrus.Fields{
@@ -161,7 +161,7 @@ func (w *Watcher) sendUpdates(ctx context.Context, ns string, out chan Event) {
 			}).Debug("Interface down or not running")
 			if _, ok := w.current[iface]; ok {
 				delete(w.current, iface)
-				out <- Event{Type: EventDeleted, Interface: iface}
+				out <- Event{Type: EventDeleted, Interface: &iface}
 			}
 		}
 		w.mutex.Unlock()

--- a/pkg/ifaces/watcher_test.go
+++ b/pkg/ifaces/watcher_test.go
@@ -21,7 +21,7 @@ func TestWatcher(t *testing.T) {
 	watcher := NewWatcher(10)
 	// mock net.Interfaces and linkSubscriber to control which interfaces are discovered
 	watcher.interfaces = func(_ netns.NsHandle, _ string) ([]Interface, error) {
-		return []Interface{{"foo", 1, macFoo, netns.None(), ""}, {"bar", 2, macBar, netns.None(), ""}, {"baz", 3, macBaz, netns.None(), ""}}, nil
+		return []Interface{{"foo", 1, macFoo, netns.None(), "", TCHook}, {"bar", 2, macBar, netns.None(), "", TCHook}, {"baz", 3, macBaz, netns.None(), "", TCHook}}, nil
 	}
 	inputLinks := make(chan netlink.LinkUpdate, 10)
 	watcher.linkSubscriberAt = func(_ netns.NsHandle, ch chan<- netlink.LinkUpdate, _ <-chan struct{}) error {
@@ -38,23 +38,23 @@ func TestWatcher(t *testing.T) {
 
 	// initial set of fetched elements
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"foo", 1, macFoo, netns.None(), ""}},
+		Event{Type: EventAdded, Interface: &Interface{"foo", 1, macFoo, netns.None(), "", TCHook}},
 		getEvent(t, outputEvents, timeout))
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"bar", 2, macBar, netns.None(), ""}},
+		Event{Type: EventAdded, Interface: &Interface{"bar", 2, macBar, netns.None(), "", TCHook}},
 		getEvent(t, outputEvents, timeout))
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"baz", 3, macBaz, netns.None(), ""}},
+		Event{Type: EventAdded, Interface: &Interface{"baz", 3, macBaz, netns.None(), "", TCHook}},
 		getEvent(t, outputEvents, timeout))
 
 	// updates
 	inputLinks <- upAndRunning("bae", 4, macBae[:], netns.None())
 	inputLinks <- down("bar", 2, macBar[:], netns.None())
 	assert.Equal(t,
-		Event{Type: EventAdded, Interface: Interface{"bae", 4, macBae, netns.None(), ""}},
+		Event{Type: EventAdded, Interface: &Interface{"bae", 4, macBae, netns.None(), "", TCHook}},
 		getEvent(t, outputEvents, timeout))
 	assert.Equal(t,
-		Event{Type: EventDeleted, Interface: Interface{"bar", 2, macBar, netns.None(), ""}},
+		Event{Type: EventDeleted, Interface: &Interface{"bar", 2, macBar, netns.None(), "", TCHook}},
 		getEvent(t, outputEvents, timeout))
 
 	// repeated updates that do not involve a change in the current track of interfaces

--- a/pkg/test/informer_fake.go
+++ b/pkg/test/informer_fake.go
@@ -13,7 +13,7 @@ type SliceInformerFake []ifaces.Interface
 func (sif SliceInformerFake) Subscribe(_ context.Context) (<-chan ifaces.Event, error) {
 	ifs := make(chan ifaces.Event, len(sif))
 	for _, i := range sif {
-		ifs <- ifaces.Event{Type: ifaces.EventAdded, Interface: i}
+		ifs <- ifaces.Event{Type: ifaces.EventAdded, Interface: &i}
 	}
 	return ifs, nil
 }

--- a/pkg/test/tracer_fake.go
+++ b/pkg/test/tracer_fake.go
@@ -31,21 +31,21 @@ func NewTracerFake() *TracerFake {
 func (m *TracerFake) Close() error {
 	return nil
 }
-func (m *TracerFake) Register(iface ifaces.Interface) error {
-	m.interfaces[iface] = struct{}{}
+func (m *TracerFake) Register(iface *ifaces.Interface) error {
+	m.interfaces[*iface] = struct{}{}
 	return nil
 }
 
-func (m *TracerFake) UnRegister(iface ifaces.Interface) error {
-	m.interfaces[iface] = struct{}{}
+func (m *TracerFake) UnRegister(iface *ifaces.Interface) error {
+	m.interfaces[*iface] = struct{}{}
 	return nil
 }
 
-func (m *TracerFake) AttachTCX(_ ifaces.Interface) error {
+func (m *TracerFake) AttachTCX(_ *ifaces.Interface) error {
 	return nil
 }
 
-func (m *TracerFake) DetachTCX(_ ifaces.Interface) error {
+func (m *TracerFake) DetachTCX(_ *ifaces.Interface) error {
 	return nil
 }
 


### PR DESCRIPTION
- New metric netobserv_agent_interface_events_total
- New METRICS_LEVEL config, similar to LOG_LEVEL, that increases precision/details at the expanse of increased cardinality (only "info" and "debug" levels are offered, default is info)
- Some logs rewritting / releveled, mostly to avoid tons of interface events related logs when using LogLevel=info
