### PR TITLE
Add config option to decide if TCX can fallback to TC on errors or not

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -244,6 +244,9 @@ type Agent struct {
 	// E.g. "0a:58=eth0" (used for ovn-kubernetes)
 	PreferredInterfaceForMACPrefix string `env:"PREFERRED_INTERFACE_FOR_MAC_PREFIX"`
 
+	// EnableTCXFallBackToTC enables TCX fallback to TC when errors are encountered, default is false.
+	EnableTCXFallBackToTC bool `env:"ENABLE_TCX_FALLBACK_TO_TC" envDefault:"false"`
+
 	/* Deprecated configs are listed below this line
 	 * See manageDeprecatedConfigs function for details
 	 */

--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -117,6 +117,7 @@ type FlowFetcherConfig struct {
 	BpfManBpfFSPath                string
 	EnableIPsecTracker             bool
 	FilterConfig                   []*FilterConfig
+	EnableTCXFallBackToTC          bool
 }
 
 type variablesMapping struct {


### PR DESCRIPTION
## Description

Controll TCX fall back to TC behavior, in recent kernel we shouldn't try to drop to TC if TCX fail instead know/debug/fix the failure instead
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
