### PR TITLE
NETOBSERV-2289: fix FD leak with tcx links

### DIFF
--- a/pkg/agent/interfaces_listener.go
+++ b/pkg/agent/interfaces_listener.go
@@ -240,7 +240,7 @@ func (i *interfaceListener) detachTC(event *retriableEvent) {
 }
 
 func (i *interfaceListener) detachTCX(event *retriableEvent) {
-	if complete, err := i.runWithRetries(event, runInNamespace("Detach", i.attacher.DetachTCX)); complete {
+	if complete, err := i.runWithRetries(event, i.attacher.DetachTCX); complete {
 		if err != nil {
 			i.increaseErrors(err, false)
 			ilog.WithField("interface", event.Interface).WithField("retries", event.attempt).WithError(err).Warn("interface deleted, could not detach TCX hook")
@@ -253,7 +253,7 @@ func (i *interfaceListener) detachTCX(event *retriableEvent) {
 }
 
 func (i *interfaceListener) detachAny(event *retriableEvent) {
-	if err1 := runInNamespace("Detach", i.attacher.DetachTCX)(&event.Interface); err1 != nil {
+	if err1 := i.attacher.DetachTCX(&event.Interface); err1 != nil {
 		i.increaseErrors(err1, false)
 		if err2 := i.attacher.UnRegister(&event.Interface); err2 != nil {
 			ilog.WithField("interface", event.Interface).WithError(err2).Warn("interface deleted, could not detach any hook")


### PR DESCRIPTION
## Description

Leak happened when failing to set netns while detaching TCX. Since it's not necessary to set netns while detaching, just removing that code should fix the leak.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [x] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test ebpf-node-density-heavy-25nodes`_
