### PR TITLE
NETOBSERV-2355: Rename sampling ratio/rate -> interval

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -30,7 +30,7 @@ The following environment variables are available to configure the NetObserv eBP
   Any interface with an associated IP address within the given ranges will be listened on. This is an
   alternative to specifying `INTERFACES`, useful when you know ahead of time what IP or IP range an
   interface will have but not the OS-assigned interface name itself. Exclusive with INTERFACES/EXCLUDE_INTERFACES.
-* `SAMPLING` (default: disabled). Rate at which packets should be sampled and sent to the target
+* `SAMPLING` (default: disabled). Interval at which packets should be sampled and sent to the target
   collector. E.g. if set to 10, one out of 10 packets, on average, will be sent to the target
   collector.
 * `CACHE_MAX_FLOWS` (default: `5000`). Number of flows that can be accumulated in the accounting

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -137,7 +137,7 @@ type Agent struct {
 	Direction string `env:"DIRECTION" envDefault:"both"`
 	// Logger level. From more to less verbose: trace, debug, info, warn, error, fatal, panic.
 	LogLevel string `env:"LOG_LEVEL" envDefault:"info"`
-	// Sampling holds the rate at which packets should be sampled and sent to the target collector.
+	// Sampling holds the interval at which packets should be sampled and sent to the target collector.
 	// E.g. if set to 100, one out of 100 packets, on average, will be sent to the target collector.
 	Sampling int `env:"SAMPLING" envDefault:"0"`
 	// TCAttachMode defines the eBPF attach mode on traffic controller: tcx (default), tc or any.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -131,7 +131,7 @@ var (
 	)
 	samplingRate = defineMetric(
 		"sampling_rate",
-		"Sampling rate",
+		"Sampling interval",
 		TypeGauge,
 	)
 	errorsCounter = defineMetric(


### PR DESCRIPTION
## Description

Just doc/text renamings...

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test ebpf-node-density-heavy-25nodes`_
