### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for netobserv-ebpf-agent-zstream

### DIFF
--- a/Dockerfile.downstream
+++ b/Dockerfile.downstream
@@ -32,7 +32,8 @@ USER 65532:65532
 ENTRYPOINT ["/netobserv-ebpf-agent"]
 
 LABEL com.redhat.component="network-observability-ebpf-agent-container"
-LABEL name="network-observability-ebpf-agent"
+LABEL name="network-observability/network-observability-ebpf-agent-rhel9"
+LABEL cpe="cpe:/a:redhat:network_observ_optr:1.9::el9"
 LABEL io.k8s.display-name="Network Observability eBPF Agent"
 LABEL io.k8s.description="Network Observability eBPF Agent"
 LABEL summary="Network Observability eBPF Agent"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
