### PR TITLE
add support for specifying the anchor to use when tcx attaching programs to ingress and egress

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -161,6 +161,8 @@ func FlowsAgent(cfg *config.Agent) (*Flows, error) {
 	ebpfConfig := &tracer.FlowFetcherConfig{
 		EnableIngress:                  ingress,
 		EnableEgress:                   egress,
+		IngressTCXAnchor:               cfg.TCXAttachAnchorIngress,
+		EgressTCXAnchor:                cfg.TCXAttachAnchorEgress,
 		Debug:                          debug,
 		Sampling:                       cfg.Sampling,
 		CacheMaxSize:                   cfg.CacheMaxFlows,

--- a/pkg/agent/packets_agent.go
+++ b/pkg/agent/packets_agent.go
@@ -90,14 +90,16 @@ func PacketsAgent(cfg *config.Agent) (*Packets, error) {
 		})
 	}
 	ebpfConfig := &tracer.FlowFetcherConfig{
-		EnableIngress:  ingress,
-		EnableEgress:   egress,
-		Debug:          debug,
-		Sampling:       cfg.Sampling,
-		CacheMaxSize:   cfg.CacheMaxFlows,
-		EnablePCA:      cfg.EnablePCA,
-		UseEbpfManager: cfg.EbpfProgramManagerMode,
-		FilterConfig:   filterRules,
+		EnableIngress:    ingress,
+		EnableEgress:     egress,
+		IngressTCXAnchor: cfg.TCXAttachAnchorIngress,
+		EgressTCXAnchor:  cfg.TCXAttachAnchorEgress,
+		Debug:            debug,
+		Sampling:         cfg.Sampling,
+		CacheMaxSize:     cfg.CacheMaxFlows,
+		EnablePCA:        cfg.EnablePCA,
+		UseEbpfManager:   cfg.EbpfProgramManagerMode,
+		FilterConfig:     filterRules,
 	}
 
 	fetcher, err := tracer.NewPacketFetcher(ebpfConfig)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -147,6 +147,18 @@ type Agent struct {
 	// TCAttachRetries defines the number of retries in case of attach/detach failures.
 	// Valid only for 'tc' and 'tcx' attach modes.
 	TCAttachRetries int `env:"TC_ATTACH_RETRIES" envDefault:"4"`
+	// TCXAttachAnchorIngress defines the anchor to use when attaching eBPF programs to interfaces using tcx mode for
+	// ingress.
+	// none (default): no specific anchor is used and the eBPF program is generally inserted at the end.
+	// head: eBPF program is inserted at the head.
+	// tail: eBPF program is inserted at the tail.
+	TCXAttachAnchorIngress string `env:"TCX_ATTACH_ANCHOR_INGRESS" envDefault:"none"`
+	// TCXAttachAnchorEgress defines the anchor to use when attaching eBPF programs to interfaces using tcx mode for
+	// egress.
+	// none (default): no specific anchor is used and the eBPF program is generally inserted at the end.
+	// head: eBPF program is inserted at the head.
+	// tail: eBPF program is inserted at the tail.
+	TCXAttachAnchorEgress string `env:"TCX_ATTACH_ANCHOR_EGRESS" envDefault:"none"`
 	// ListenInterfaces specifies the mechanism used by the agent to listen for added or removed
 	// network interfaces. Accepted values are "watch" (default) or "poll".
 	// If the value is "watch", interfaces are traced immediately after they are created. This is


### PR DESCRIPTION
## Description

As per title, this adds supports for specifying the anchor to use when TCX attaching programs to ingress and egress.

We'd like to use netobserv-ebpf-agent in our clusters, however we've found that when running alongside Cilium, the agent's ingress and egress BPF programs are inserted **after** Cilium's BPF programs. This is due to no particular anchor being used, which generally results in the program being placed last.

For example:

```
lxc6e83bd0074e0(10) tcx/ingress cil_from_container prog_id 1310 link_id 260 
lxc6e83bd0074e0(10) tcx/ingress tcx_ingress_flow_parse prog_id 1503 link_id 367 
lxc6e83bd0074e0(10) tcx/egress cil_to_container prog_id 1322 link_id 262 
lxc6e83bd0074e0(10) tcx/egress tcx_egress_flow_parse prog_id 1501 link_id 366 
```
(Cilium's programs are prefixed with `cil_`)

Due to Cilium's use of `TC_ACT_REDIRECT` (which is a perfectly fine optimisation) often the agent's BPF program isn't run and we cannot capture flows.

To remedy, we've found placing the agent's BPF program at the head of the program list using `anchor.Head()`, which allows flows to be captured and then Cilium to continue processing as normal.

When using the new configuration options `TCX_ATTACH_ANCHOR_INGRESS=head` and `TCX_ATTACH_ANCHOR_EGRESS=head` we now see:

```
lxc6e83bd0074e0(10) tcx/ingress tcx_ingress_flow_parse prog_id 1527 link_id 387 
lxc6e83bd0074e0(10) tcx/ingress cil_from_container prog_id 1310 link_id 260 
lxc6e83bd0074e0(10) tcx/egress tcx_egress_flow_parse prog_id 1525 link_id 386 
lxc6e83bd0074e0(10) tcx/egress cil_to_container prog_id 1322 link_id 262 
```

I've kept default behaviour by having a `nil` anchor when `TCX_ATTACH_ANCHOR_INGRESS` or `TCX_ATTACH_ANCHOR_EGRESS` is either not specified or set to `none`.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test ebpf-node-density-heavy-25nodes`_
