### PR TITLE
[nit/trivial] Improve interface log format

### DIFF
--- a/pkg/ifaces/informer.go
+++ b/pkg/ifaces/informer.go
@@ -42,10 +42,18 @@ type Interface struct {
 	NetNS netns.NsHandle
 }
 
+func (i Interface) String() string {
+	return fmt.Sprintf("key=[%s] mac=%v netns=%s", i.InterfaceKey, i.MAC, i.NetNS)
+}
+
 type InterfaceKey struct {
 	Index  int
 	Name   string
 	NSName string
+}
+
+func (k InterfaceKey) String() string {
+	return fmt.Sprintf("index=%d name=%s ns=%s", k.Index, k.Name, k.NSName)
 }
 
 func NewInterface(index int, name string, mac [6]uint8, netNS netns.NsHandle, nsname string) Interface {


### PR DESCRIPTION
Interface logs were not always simple to read, e.g: 

```
"failed to attach TCX Egress: attach tcx link: no such device" interface="{{98 svc-sigk-left0 28027243-538d-4952-a5aa-1bd973aa09da} [58 237 126 214 200 103] NS(2154: 4, 4026556969)}" 
```
now it's more clear what each of these values are

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test ebpf-node-density-heavy-25nodes`_
