### PR TITLE
Rename TLSCurve => TLSGroup

### DIFF
--- a/pkg/decode/decode_protobuf.go
+++ b/pkg/decode/decode_protobuf.go
@@ -106,7 +106,7 @@ func RecordToMap(fr *model.Record) config.GenericMap {
 		out["TLSCipherSuite"] = tls.CipherSuiteName(fr.Metrics.TlsCipherSuite)
 	}
 	if fr.Metrics.TlsKeyShare != 0 {
-		out["TLSCurve"] = tls.CurveID(fr.Metrics.TlsKeyShare).String()
+		out["TLSGroup"] = tls.CurveID(fr.Metrics.TlsKeyShare).String()
 	}
 
 	if fr.Metrics.EthProtocol == uint16(ethernet.EtherTypeIPv4) || fr.Metrics.EthProtocol == uint16(ethernet.EtherTypeIPv6) {

--- a/pkg/exporter/converters_test.go
+++ b/pkg/exporter/converters_test.go
@@ -85,7 +85,7 @@ func TestConversions(t *testing.T) {
 				"IPSecStatus":     "success",
 				"TLSVersion":      "TLS 1.3",
 				"TLSCipherSuite":  "TLS_AES_256_GCM_SHA384",
-				"TLSCurve":        "X25519",
+				"TLSGroup":        "X25519",
 				"TLSTypes":        []string{"ServerHello", "AppData"},
 			},
 		},


### PR DESCRIPTION
See https://www.rfc-editor.org/rfc/rfc7919 for info about the renaming

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
- Operator: https://github.com/netobserv/netobserv-operator/pull/2707

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test ebpf-node-density-heavy-25nodes`_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated TLS metric field naming for improved consistency and accuracy in network diagnostics. The elliptic-curve identifier field has been standardized to enhance clarity when tracking secure TLS connection parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->