### PR TITLE
Fix pprof broad exposition

### DIFF
--- a/cmd/netobserv-ebpf-agent.go
+++ b/cmd/netobserv-ebpf-agent.go
@@ -13,6 +13,7 @@ import (
 	"github.com/caarlos0/env/v11"
 	"github.com/sirupsen/logrus"
 
+	"github.com/netobserv/flowlogs-pipeline/pkg/server"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/agent"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/config"
 
@@ -45,10 +46,11 @@ func main() {
 	}
 	setLoggerVerbosity(&config)
 
-	if config.ProfilePort != 0 {
+	if config.PprofAddr != "" {
 		go func() {
-			logrus.WithField("port", config.ProfilePort).Info("starting PProf HTTP listener")
-			logrus.WithError(http.ListenAndServe(fmt.Sprintf(":%d", config.ProfilePort), nil)).
+			logrus.WithField("addr", config.PprofAddr).Info("starting PProf HTTP listener")
+			srv := server.Default(&http.Server{Addr: config.PprofAddr})
+			logrus.WithError(srv.ListenAndServe()).
 				Error("PProf HTTP listener stopped working")
 		}()
 	}

--- a/cmd/netobserv-ebpf-agent.go
+++ b/cmd/netobserv-ebpf-agent.go
@@ -49,7 +49,7 @@ func main() {
 	if config.PprofAddr != "" {
 		go func() {
 			logrus.WithField("addr", config.PprofAddr).Info("starting PProf HTTP listener")
-			srv := server.Default(&http.Server{Addr: config.PprofAddr})
+			srv := server.Default(&http.Server{Addr: config.PprofAddr, Handler: http.DefaultServeMux})
 			logrus.WithError(srv.ListenAndServe()).
 				Error("PProf HTTP listener stopped working")
 		}()

--- a/cmd/netobserv-ebpf-agent.go
+++ b/cmd/netobserv-ebpf-agent.go
@@ -13,9 +13,9 @@ import (
 	"github.com/caarlos0/env/v11"
 	"github.com/sirupsen/logrus"
 
-	"github.com/netobserv/flowlogs-pipeline/pkg/server"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/agent"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/config"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/server"
 
 	_ "net/http/pprof"
 )

--- a/docs/config.md
+++ b/docs/config.md
@@ -74,8 +74,8 @@ The following environment variables are available to configure the NetObserv eBP
   * `KAFKA_TLS_CA_CERT_PATH` (default: unset). Path to the Kafka server certificate for TLS connections.
   * `KAFKA_TLS_USER_CERT_PATH` (default: unset). Path to the user (client) certificate for mutual TLS connections.
   * `KAFKA_TLS_USER_KEY_PATH` (default: unset). Path to the user (client) private key for mutual TLS connections.
-* `PROFILE_PORT` (default: unset). Sets the listening port for [Go's Pprof tool](https://pkg.go.dev/net/http/pprof).
-  If it is not set, profile is disabled.
+* `PPROF_ADDR` (default: unset). Sets the listening address for [Go's Pprof tool](https://pkg.go.dev/net/http/pprof). Do not expose publicly.
+  If it is not set, profiling is disabled.
 * `ENABLE_RTT` (default: `false` disabled). If `true` enables RTT calculations for the captured flows in the ebpf agent.
   See [docs](./rtt_calculations.md) for more details on this feature.
 * `ENABLE_PKT_DROPS` (default: `false` disabled). If `true` enables packet drops eBPF hook to be able to capture drops flows in the ebpf agent.

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,8 +1,9 @@
 # Profiling guide
 
-1. Run the agent with the `PROFILE_PORT` variable set to e.g. 6060.
-   - If you are executing the agent from the Openshift NetObserv Operator, you can do it by
+1. Run the agent with the `PPROF_ADDR` variable set to a listening address. For security, prefer using the local loop ("127.0.0.1:6060") rather than a broader exposition ("0.0.0.0:6060" or ":6060"), or make sure to restrict who has access to this address, as it can leak sensitive data.
+   - If you are executing the agent from the NetObserv Operator, you can do it by
      adding the following section to your `ebpf` spec:
+
    ```yaml
    apiVersion: flows.netobserv.io/v1alpha1
    kind: FlowCollector
@@ -11,15 +12,15 @@
    spec:
      agent:
        ebpf:
-         debug:
+         advanced:
            env:
-             PROFILE_PORT: "6060"
+             PPROF_ADDR: "127.0.0.1:6060"
     ```
 
-2. If you are running OpenShift/Kubernetes, port-forward the pod that you want to profile.
+2. If you are running Kubernetes, port-forward the pod that you want to profile.
 
     ```
-    oc -n netobserv-privileged port-forward <netobserv-ebpf-agent pod name> 6060
+    kubectl -n netobserv-privileged port-forward <netobserv-ebpf-agent pod name> 6060
     ```
    
 3. Download the required profiles:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -218,8 +218,8 @@ type Agent struct {
 	KafkaSASLClientIDPath string `env:"KAFKA_SASL_CLIENT_ID_PATH"`
 	// KafkaSASLClientSecretPath is the path to the client secret (password) for SASL auth
 	KafkaSASLClientSecretPath string `env:"KAFKA_SASL_CLIENT_SECRET_PATH"`
-	// ProfilePort sets the listening port for Go's Pprof tool. If it is not set, profile is disabled
-	ProfilePort int `env:"PROFILE_PORT"`
+	// PPROF_ADDR sets the listening address (such as 127.0.0.1:6060) for Go's Pprof tool. Do not expose publicly. If it is not set, profiling is disabled.
+	PprofAddr string `env:"PPROF_ADDR"`
 	// Flowlogs-pipeline configuration as YAML or JSON, used when export is "direct-flp". Cf https://github.com/netobserv/flowlogs-pipeline
 	// The "ingest" stage must be omitted from this configuration, since it is handled internally by the agent. The first stage should follow "preset-ingester".
 	// E.g: {"pipeline":[{"name": "writer","follows": "preset-ingester"}],"parameters":[{"name": "writer","write": {"type": "stdout"}}]}.

--- a/pkg/prometheus/prom_server.go
+++ b/pkg/prometheus/prom_server.go
@@ -4,9 +4,9 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/metrics"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/server"
 
 	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -50,7 +50,7 @@ func StartServerAsync(conn *metrics.Settings, registry *prom.Registry) *http.Ser
 		mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
 	}
 	httpServer.Handler = mux
-	httpServer = defaultServer(httpServer)
+	httpServer = server.Default(httpServer)
 
 	go func() {
 		var err error
@@ -65,39 +65,4 @@ func StartServerAsync(conn *metrics.Settings, registry *prom.Registry) *http.Ser
 	}()
 
 	return httpServer
-}
-
-func defaultServer(srv *http.Server) *http.Server {
-	// defaults taken from https://bruinsslot.jp/post/go-secure-webserver/ can be overriden by caller
-	if srv.Handler != nil {
-		// No more than 2MB body
-		srv.Handler = http.MaxBytesHandler(srv.Handler, 2<<20)
-	} else {
-		plog.Warnf("Handler not yet set on server while securing defaults. Make sure a MaxByte middleware is used.")
-	}
-	if srv.ReadTimeout == 0 {
-		srv.ReadTimeout = 10 * time.Second
-	}
-	if srv.ReadHeaderTimeout == 0 {
-		srv.ReadHeaderTimeout = 5 * time.Second
-	}
-	if srv.WriteTimeout == 0 {
-		srv.WriteTimeout = 10 * time.Second
-	}
-	if srv.IdleTimeout == 0 {
-		srv.IdleTimeout = 120 * time.Second
-	}
-	if srv.MaxHeaderBytes == 0 {
-		srv.MaxHeaderBytes = 1 << 20 // 1MB
-	}
-	if srv.TLSConfig == nil {
-		srv.TLSConfig = &tls.Config{}
-	}
-	if srv.TLSConfig.MinVersion == 0 {
-		srv.TLSConfig.MinVersion = tls.VersionTLS13
-	}
-	// Disable http/2
-	srv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0)
-
-	return srv
 }

--- a/pkg/server/common.go
+++ b/pkg/server/common.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"crypto/tls"
+	"net/http"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+var slog = logrus.WithField("module", "server")
+
+func Default(srv *http.Server) *http.Server {
+	// defaults taken from https://bruinsslot.jp/post/go-secure-webserver/ can be overriden by caller
+	if srv.Handler != nil {
+		// No more than 2MB body
+		srv.Handler = http.MaxBytesHandler(srv.Handler, 2<<20)
+	} else {
+		slog.Warnf("Handler not yet set on server while securing defaults. Make sure a MaxByte middleware is used.")
+	}
+	if srv.ReadTimeout == 0 {
+		srv.ReadTimeout = 10 * time.Second
+	}
+	if srv.ReadHeaderTimeout == 0 {
+		srv.ReadHeaderTimeout = 5 * time.Second
+	}
+	if srv.WriteTimeout == 0 {
+		srv.WriteTimeout = 10 * time.Second
+	}
+	if srv.IdleTimeout == 0 {
+		srv.IdleTimeout = 120 * time.Second
+	}
+	if srv.MaxHeaderBytes == 0 {
+		srv.MaxHeaderBytes = 1 << 20 // 1MB
+	}
+	if srv.TLSConfig == nil {
+		srv.TLSConfig = &tls.Config{}
+	}
+	if srv.TLSConfig.MinVersion == 0 {
+		srv.TLSConfig.MinVersion = tls.VersionTLS13
+	}
+	// Disable http/2
+	srv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0)
+
+	return srv
+}


### PR DESCRIPTION
## Description

When pprof was enabled, it was exposed on ":(port)" which stands for all net interfaces.

Settings are changed so the user controls what address to use. For example, they can configure it with "127.0.0.1:6060" to restrict to the local loop (more secured), or keep ":6060" or "0.0.0.0:6060" for a broader exposition. Documented those security aspects.

Note that this setting is not exposed in netobserv API, but can still be configured using the environment variable.

Additionally, the pprof server now uses the common safeguards against resource exhaustion attacks

*Breaking changes*:
- config for pprof changed from env "PROFILE_PORT" to "PPROF_ADDR", now including the listening address.


## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
- operator: https://github.com/netobserv/netobserv-operator/pull/2821
- flp: https://github.com/netobserv/flowlogs-pipeline/pull/1286

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test ebpf-node-density-heavy-25nodes`_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * Profiling configuration now uses `PPROF_ADDR` (string listen address) instead of `PROFILE_PORT`; profiling is disabled when `PPROF_ADDR` isn’t set.

* **Security Improvements**
  * Hardened HTTP server defaults across services, including secure TLS baseline (TLS 1.3 minimum), safer request/body limits, and improved timeout handling.

* **Documentation**
  * Updated configuration and profiling guides with `PPROF_ADDR`, including revised example settings and Kubernetes port-forward guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->