### PR TITLE
test(bench): add benchmark harness for flow hot paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,11 @@ PROTOC_ARTIFACTS := pkg/pbflow
 # regular expressions for excluded file patterns
 EXCLUDE_COVERAGE_FILES="(/cmd/)|(bpf_bpfe)|(/examples/)|(/pkg/pbflow/)"
 
+# Benchmark configuration (override on the command line, e.g. make bench BENCH_COUNT=10)
+BENCH_PKGS ?= ./pkg/model/... ./pkg/flow/... ./pkg/pbflow/...
+BENCH_RUN ?= .
+BENCH_COUNT ?= 6
+
 # Container image for running linux tests from non-linux hosts (e.g. macOS).
 # Prefer matching the *host* Go toolchain version (go env GOVERSION), which tends to
 # be more reliable than GO_VERSION (used for generator tooling) and avoids "go: not found".
@@ -178,6 +183,11 @@ test: ## Test code using go test
 	else \
 		$(MAKE) test-container; \
 	fi
+
+.PHONY: bench
+bench: ## Run Go benchmarks (memory hot paths). Use BENCH_PKGS, BENCH_RUN, BENCH_COUNT to customize.
+	@echo "### Running benchmarks"
+	go test -mod vendor -run '^$$' -bench '$(BENCH_RUN)' -benchmem -count $(BENCH_COUNT) $(BENCH_PKGS)
 
 .PHONY: test-container
 test-container: ## Run linux tests in a container (useful on macOS)

--- a/pkg/flow/tracer_map_bench_test.go
+++ b/pkg/flow/tracer_map_bench_test.go
@@ -3,6 +3,7 @@ package flow
 import (
 	"context"
 	"net"
+	"strconv"
 	"testing"
 	"time"
 
@@ -114,24 +115,8 @@ func sizeName(n int) string {
 	case n >= 1000000:
 		return "1M"
 	case n >= 1000:
-		return itoaK(n)
+		return strconv.Itoa(n/1000) + "k"
 	default:
-		return itoa(n)
+		return strconv.Itoa(n)
 	}
-}
-
-func itoaK(n int) string { return itoa(n/1000) + "k" }
-
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	var buf [20]byte
-	pos := len(buf)
-	for n > 0 {
-		pos--
-		buf[pos] = byte('0' + n%10)
-		n /= 10
-	}
-	return string(buf[pos:])
 }

--- a/pkg/flow/tracer_map_bench_test.go
+++ b/pkg/flow/tracer_map_bench_test.go
@@ -1,0 +1,137 @@
+package flow
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/ebpf"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/metrics"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/model"
+)
+
+// benchFakeFetcher is an in-memory mapFetcher that returns a fresh copy of a
+// pre-built flow map on each LookupAndDeleteMap call, so we can benchmark the
+// userspace eviction/record-building cost in isolation from the kernel.
+type benchFakeFetcher struct {
+	flows map[ebpf.BpfFlowId]model.BpfFlowContent
+}
+
+func (f *benchFakeFetcher) LookupAndDeleteMap(_ *metrics.Metrics) map[ebpf.BpfFlowId]model.BpfFlowContent {
+	// Return a copy: evictFlows consumes the map, and we want each iteration to
+	// process the same population.
+	out := make(map[ebpf.BpfFlowId]model.BpfFlowContent, len(f.flows))
+	for k, v := range f.flows {
+		out[k] = v
+	}
+	return out
+}
+
+func (f *benchFakeFetcher) DeleteMapsStaleEntries(_ time.Duration) {}
+
+func benchBuildFlowMap(n int) map[ebpf.BpfFlowId]model.BpfFlowContent {
+	m := make(map[ebpf.BpfFlowId]model.BpfFlowContent, n)
+	for i := 0; i < n; i++ {
+		var id ebpf.BpfFlowId
+		src := net.IPv4(10, byte(i>>16), byte(i>>8), byte(i)).To16()
+		dst := net.IPv4(10, byte(i>>16), byte(i>>8), byte(i+1)).To16()
+		copy(id.SrcIp[:], src)
+		copy(id.DstIp[:], dst)
+		id.SrcPort = uint16(1024 + (i % 60000))
+		id.DstPort = 443
+		id.TransportProtocol = 6
+		m[id] = model.NewBpfFlowContent(ebpf.BpfFlowMetrics{
+			StartMonoTimeTs:  uint64(1_000_000 + i),
+			EndMonoTimeTs:    uint64(2_000_000 + i),
+			Bytes:            uint64(1500 * (1 + i%10)),
+			Packets:          uint32(1 + i%10),
+			EthProtocol:      0x0800,
+			Flags:            0x10,
+			SrcMac:           [6]uint8{0x02, 0, 0, 0, 0, 0x01},
+			DstMac:           [6]uint8{0x02, 0, 0, 0, 0, 0x02},
+			IfIndexFirstSeen: uint32(2 + i%4),
+		})
+	}
+	return m
+}
+
+// BenchmarkEvictFlows measures the full userspace eviction: reading the map and
+// converting every entry into a *model.Record forwarded down the pipeline. This
+// is the end-to-end per-eviction cost that drives peak heap on busy nodes.
+//
+// Sizes are chosen to bracket realistic CACHE_MAX_FLOWS values.
+func BenchmarkEvictFlows(b *testing.B) {
+	model.SetInterfaceNamer(func(ifIndex int, _ model.MacAddr) string {
+		switch ifIndex {
+		case 2:
+			return "eth0"
+		case 3:
+			return "eth1"
+		case 4:
+			return "eth2"
+		default:
+			return "eth3"
+		}
+	})
+	model.SetGlobalIP([]byte{10, 0, 0, 1})
+
+	// Create the metrics and tracer once (NewMapTracer registers a histogram on
+	// the global Prometheus registry, so constructing it per-size would emit
+	// duplicate-registration warnings). We swap the fetcher's population per size.
+	m := metrics.NoOp()
+	fetcher := &benchFakeFetcher{}
+	mt := NewMapTracer(fetcher, time.Hour, time.Hour, m, nil, false)
+
+	for _, n := range []int{1000, 10000, 100000} {
+		b.Run(sizeName(n), func(b *testing.B) {
+			fetcher.flows = benchBuildFlowMap(n)
+			out := make(chan []*model.Record, 1)
+			ctx := context.Background()
+
+			// Drain the output channel so evictFlows never blocks.
+			done := make(chan struct{})
+			go func() {
+				for range out {
+				}
+				close(done)
+			}()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				mt.evictFlows(ctx, false, out)
+			}
+			b.StopTimer()
+			close(out)
+			<-done
+		})
+	}
+}
+
+func sizeName(n int) string {
+	switch {
+	case n >= 1000000:
+		return "1M"
+	case n >= 1000:
+		return itoaK(n)
+	default:
+		return itoa(n)
+	}
+}
+
+func itoaK(n int) string { return itoa(n/1000) + "k" }
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for n > 0 {
+		pos--
+		buf[pos] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[pos:])
+}

--- a/pkg/model/bench_fixtures_test.go
+++ b/pkg/model/bench_fixtures_test.go
@@ -48,10 +48,9 @@ func benchFlowMetrics(i int) ebpf.BpfFlowMetrics {
 	}
 }
 
-// BenchFlowContent builds a BpfFlowContent for the given index (exported for use
-// by benchmarks in other packages via the model package's test binary is not
-// possible; kept lowercase and used within-package). See BenchRecords below for
-// cross-package needs.
+// benchFlowContent builds a BpfFlowContent for the given index. It is kept
+// unexported and used only within this package's benchmarks; other packages
+// build their own equivalent fixtures locally.
 func benchFlowContent(i int) BpfFlowContent {
 	return NewBpfFlowContent(benchFlowMetrics(i))
 }

--- a/pkg/model/bench_fixtures_test.go
+++ b/pkg/model/bench_fixtures_test.go
@@ -1,0 +1,57 @@
+package model
+
+import (
+	"net"
+
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/ebpf"
+)
+
+// This file provides shared fixtures for the memory hot-path benchmarks.
+//
+// These generators mirror the flows produced in the agent's default/common
+// deployment (EXPORT=grpc, SAMPLING off, no DNS/RTT/drops/network-events/PCA/
+// UDN/TLS features). They deliberately populate ONLY the base BpfFlowMetrics so
+// the benchmarks measure the path that actually runs in that configuration.
+
+// benchFlowID returns a synthetic, unique-ish flow id. Varying the low bytes of
+// the IPs/ports by i keeps map keys distinct so cache/eviction benchmarks behave
+// like a real high-cardinality node.
+func benchFlowID(i int) ebpf.BpfFlowId {
+	var id ebpf.BpfFlowId
+	// IPv4-mapped addresses (::ffff:10.x.x.x style), matching how the agent encodes v4.
+	src := net.IPv4(10, byte(i>>16), byte(i>>8), byte(i)).To16()
+	dst := net.IPv4(10, byte(i>>16), byte(i>>8), byte(i+1)).To16()
+	copy(id.SrcIp[:], src)
+	copy(id.DstIp[:], dst)
+	id.SrcPort = uint16(1024 + (i % 60000))
+	id.DstPort = 443
+	id.TransportProtocol = 6 // TCP
+	return id
+}
+
+// benchFlowMetrics returns base metrics for an IPv4 TCP flow with a single
+// interface observed (the overwhelmingly common case in production).
+func benchFlowMetrics(i int) ebpf.BpfFlowMetrics {
+	return ebpf.BpfFlowMetrics{
+		StartMonoTimeTs:    uint64(1_000_000 + i),
+		EndMonoTimeTs:      uint64(2_000_000 + i),
+		Bytes:              uint64(1500 * (1 + i%10)),
+		Packets:            uint32(1 + i%10),
+		EthProtocol:        0x0800, // IPv4
+		Flags:              0x10,   // ACK
+		SrcMac:             [6]uint8{0x02, 0x00, 0x00, 0x00, 0x00, 0x01},
+		DstMac:             [6]uint8{0x02, 0x00, 0x00, 0x00, 0x00, 0x02},
+		IfIndexFirstSeen:   uint32(2 + i%4),
+		DirectionFirstSeen: uint8(i % 2),
+		Dscp:               0,
+		NbObservedIntf:     0,
+	}
+}
+
+// BenchFlowContent builds a BpfFlowContent for the given index (exported for use
+// by benchmarks in other packages via the model package's test binary is not
+// possible; kept lowercase and used within-package). See BenchRecords below for
+// cross-package needs.
+func benchFlowContent(i int) BpfFlowContent {
+	return NewBpfFlowContent(benchFlowMetrics(i))
+}

--- a/pkg/model/record_bench_test.go
+++ b/pkg/model/record_bench_test.go
@@ -1,0 +1,63 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/ebpf"
+)
+
+// BenchmarkNewRecord measures the per-flow cost of NewRecord, which runs once
+// per flow on every cache eviction (up to CACHE_MAX_FLOWS times per interval).
+// This is the single hottest allocation site in the common (grpc, no extra
+// features) configuration.
+func BenchmarkNewRecord(b *testing.B) {
+	// Use a realistic interface namer (returns a stable string per ifindex)
+	// rather than the default fmt.Sprintf-based placeholder.
+	SetInterfaceNamer(func(ifIndex int, _ MacAddr) string {
+		switch ifIndex {
+		case 2:
+			return "eth0"
+		case 3:
+			return "eth1"
+		case 4:
+			return "eth2"
+		default:
+			return "eth3"
+		}
+	})
+	SetGlobalIP([]byte{10, 0, 0, 1})
+
+	now := time.Now()
+	mono := uint64(3_000_000)
+
+	// Pre-build the metrics so we only measure NewRecord itself.
+	contents := make([]BpfFlowContent, 1024)
+	keys := make([]ebpf.BpfFlowId, 1024)
+	for i := range contents {
+		contents[i] = benchFlowContent(i)
+		keys[i] = benchFlowID(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink *Record
+	for i := 0; i < b.N; i++ {
+		idx := i & 1023
+		sink = NewRecord(keys[idx], &contents[idx], now, mono, nil, nil)
+	}
+	_ = sink
+}
+
+// BenchmarkAccumulateBase measures the per-packet-batch merge that happens when
+// a flow id already exists in the userspace accounter cache.
+func BenchmarkAccumulateBase(b *testing.B) {
+	base := benchFlowMetrics(1)
+	other := benchFlowMetrics(2)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p := base
+		AccumulateBase(&p, &other)
+	}
+}

--- a/pkg/pbflow/proto_bench_test.go
+++ b/pkg/pbflow/proto_bench_test.go
@@ -1,0 +1,79 @@
+package pbflow
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/ebpf"
+	"github.com/netobserv/netobserv-ebpf-agent/pkg/model"
+)
+
+// benchRecord builds a *model.Record equivalent to what MapTracer.evictFlows
+// produces for a base IPv4 TCP flow with a single interface (the common,
+// no-extra-features configuration).
+func benchRecord(i int) *model.Record {
+	var id ebpf.BpfFlowId
+	src := net.IPv4(10, byte(i>>16), byte(i>>8), byte(i)).To16()
+	dst := net.IPv4(10, byte(i>>16), byte(i>>8), byte(i+1)).To16()
+	copy(id.SrcIp[:], src)
+	copy(id.DstIp[:], dst)
+	id.SrcPort = uint16(1024 + (i % 60000))
+	id.DstPort = 443
+	id.TransportProtocol = 6
+
+	now := time.Now()
+	return &model.Record{
+		ID: id,
+		Metrics: model.BpfFlowContent{
+			BpfFlowMetrics: &ebpf.BpfFlowMetrics{
+				StartMonoTimeTs: uint64(1_000_000 + i),
+				EndMonoTimeTs:   uint64(2_000_000 + i),
+				Bytes:           uint64(1500 * (1 + i%10)),
+				Packets:         uint32(1 + i%10),
+				EthProtocol:     0x0800,
+				Flags:           0x10,
+				SrcMac:          [6]uint8{0x02, 0, 0, 0, 0, 0x01},
+				DstMac:          [6]uint8{0x02, 0, 0, 0, 0, 0x02},
+			},
+		},
+		TimeFlowStart: now.Add(-time.Second),
+		TimeFlowEnd:   now,
+		AgentIP:       net.IPv4(10, 0, 0, 1),
+		Interfaces: []model.IntfDirUdn{
+			{Interface: "eth0", Direction: 0, Udn: ""},
+		},
+	}
+}
+
+// BenchmarkFlowToPB measures the per-flow protobuf conversion in the gRPC/Kafka
+// export path. It runs once per flow per eviction, so its allocation profile
+// directly affects the peak heap on busy nodes.
+func BenchmarkFlowToPB(b *testing.B) {
+	r := benchRecord(1)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink *Record
+	for i := 0; i < b.N; i++ {
+		sink = FlowToPB(r)
+	}
+	_ = sink
+}
+
+// BenchmarkFlowsToPB measures the full batch conversion of a realistic eviction
+// batch (many records -> chunked *Records messages), matching sendBatch.
+func BenchmarkFlowsToPB(b *testing.B) {
+	const n = 10000
+	batch := make([]*model.Record, n)
+	for i := range batch {
+		batch[i] = benchRecord(i)
+	}
+	const maxPerMsg = 10000 // GRPCMessageMaxFlows default
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink []*Records
+	for i := 0; i < b.N; i++ {
+		sink = FlowsToPB(batch, maxPerMsg)
+	}
+	_ = sink
+}


### PR DESCRIPTION
# Description

This PR adds a benchmark harness for the agent's per-flow memory hot paths, along with a `make bench` target to run them.

The benchmarks cover the code that runs on every cache eviction (up to `CACHE_MAX_FLOWS` times per interval): record building, map eviction, and protobuf export conversion. They exercise the common deployment configuration (gRPC export, no optional features) so they measure the allocations that dominate agent memory on busy nodes. This gives us a repeatable, benchstat-friendly baseline for future optimization work.

I intend to follow up with memory tuning work on these hot paths. Landing the benchmarks first gives a stable baseline, so I can use benchstat to demonstrate the memory and allocation improvements from those later changes.

Benchmarks added:

* `pkg/model`: `BenchmarkNewRecord`, `BenchmarkAccumulateBase`
* `pkg/flow`: `BenchmarkEvictFlows` (1k/10k/100k flows)
* `pkg/pbflow`: `BenchmarkFlowToPB`, `BenchmarkFlowsToPB`

Build and tooling changes:

* Added a `bench` target to the Makefile. It runs the benchmarks with `-benchmem` and a configurable run count.
* Configurable via `BENCH_PKGS`, `BENCH_RUN`, and `BENCH_COUNT` (for example: `make bench BENCH_COUNT=10`).

Run with:

```
make bench
```

This change is test-only. It adds new `_test.go` files and a Makefile target, and does not modify any runtime code or behaviour.

# Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

# Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [x] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test ebpf-node-density-heavy-25nodes`_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `bench` command with configurable controls for which packages to run, the benchmark selection pattern, and the number of repetitions.
  * Introduced benchmarks covering flow eviction cost, record creation, base metric accumulation, and protobuf conversion.
  * Added deterministic benchmark fixtures to generate consistent synthetic flow and record data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->