### PR TITLE
NETOBSERV-2912: Enable PQC in OpenSSL: switch to ubi-minimal-pqc base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 ARG TARGETARCH
 
+# PQC crypto-policies builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8 AS crypto-builder
+RUN microdnf install -y crypto-policies-scripts && \
+    update-crypto-policies --set DEFAULT:PQ && \
+    microdnf clean all && rm -rf /var/cache/*
+
 # Build the manager binary
 FROM docker.io/library/golang:1.26 AS builder
 
@@ -21,8 +27,9 @@ COPY go.sum go.sum
 RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -ldflags "$LDFLAGS" -mod vendor -a -o bin/netobserv-ebpf-agent cmd/netobserv-ebpf-agent.go
 
 # Create final image from minimal + built binary
-FROM --platform=linux/$TARGETARCH registry.redhat.io/ubi9/ubi-minimal-pqc:9.8
+FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi-minimal:1784092978
 WORKDIR /
+COPY --from=crypto-builder /etc/crypto-policies/ /etc/crypto-policies/
 COPY --from=builder /opt/app-root/bin/netobserv-ebpf-agent .
 USER 65532:65532
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY go.sum go.sum
 RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -ldflags "$LDFLAGS" -mod vendor -a -o bin/netobserv-ebpf-agent cmd/netobserv-ebpf-agent.go
 
 # Create final image from minimal + built binary
-FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi-minimal:1784092978
+FROM --platform=linux/$TARGETARCH registry.redhat.io/ubi9/ubi-minimal-pqc:9.8
 WORKDIR /
 COPY --from=builder /opt/app-root/bin/netobserv-ebpf-agent .
 USER 65532:65532


### PR DESCRIPTION
## Description

Enable `DEFAULT:PQ` crypto policy for post-quantum cryptography support using a multi-stage build. A `crypto-builder` stage installs `crypto-policies-scripts`, configures `DEFAULT:PQ`, and the resulting `/etc/crypto-policies/` is copied into the runtime image. This makes ML-KEM available via OpenSSL without changing the base image.

This is part of the OCP 5.0 PQC initiative ([OCPSTRAT-3113](https://issues.redhat.com/browse/OCPSTRAT-3113)). The crypto policy switch is transparent to the agent — it does not alter behavior or APIs.

**Approach:** Based on [openshift/images#230](https://github.com/openshift/images/pull/230).

**Verification:**
```bash
podman build -t ebpf-agent-pqc-test -f Dockerfile .
podman run --rm --entrypoint cat ebpf-agent-pqc-test /etc/crypto-policies/state/current
# Output: DEFAULT:PQ
```

**Images updated:**
- `Dockerfile` (eBPF agent image)

**Not affected:**
- `Containerfile.bytecode.multi.arch` (uses `scratch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve [NETOBSERV-2912](https://redhat.atlassian.net/browse/NETOBSERV-2912)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled post-quantum cryptography policy support in the container image.
* **Chores**
  * Improved image build cleanup to reduce leftover package-cache data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->