### PR TITLE
tune coderabbit to ignore vendor files

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -30,7 +30,7 @@ reviews:
   path_filters:
     # generated deepcopy
     - "!**/zz_generated.deepcopy.go"
-    - "!vendor/"
+    - "!vendor/**"
     # Generated eBPF bytecode and bindings
     - "!**/*_bpfel.go"
     - "!**/*_bpfeb.go"


### PR DESCRIPTION
I think the "**" is needed; e.g. see https://github.com/netobserv/flowlogs-pipeline/pull/1329 where it ignored the review due to too many vendor files.
If confirmed we'll need to apply it everywhere.
cc @memodi 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review path filtering to exclude all files and subdirectories within the vendor directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->